### PR TITLE
fix cut off copy in onboarding carousel, clean up styling code

### DIFF
--- a/features/onboarding/onboarding-screen.tsx
+++ b/features/onboarding/onboarding-screen.tsx
@@ -1,8 +1,9 @@
-import { OnboardingCarouselItem } from '@/ui'
+import { OnboardingCarouselItem, YStack } from '@/ui'
 import { View, Dimensions } from 'react-native'
 import { useSharedValue } from 'react-native-reanimated'
 import { useRef } from 'react'
 import { router } from 'expo-router'
+import { Button } from '@/ui/buttons/Button'
 import Carousel, { ICarouselInstance, Pagination } from 'react-native-reanimated-carousel'
 import { c, s } from '@/features/style'
 
@@ -31,18 +32,46 @@ export function OnboardingScreen() {
         height={win.height}
         enabled={true}
         renderItem={({ index }) => (
-          <OnboardingCarouselItem index={index} next={() => nextSlide(index)} done={done}>
-            <Pagination.Basic
-              data={data}
-              dotStyle={{ backgroundColor: c.grey1, borderRadius: 100 }}
-              activeDotStyle={{ backgroundColor: c.grey2, borderRadius: 100 }}
-              containerStyle={{
-                gap: s.$2,
+          <YStack
+            style={{
+              height: '100%',
+              paddingTop: s.$4,
+              paddingBottom: s.$4,
+            }}
+          >
+            <OnboardingCarouselItem index={index} />
+
+            <View
+              style={{
+                height: 100,
+                justifyContent: 'center',
               }}
-              progress={progress}
-              horizontal
-            />
-          </OnboardingCarouselItem>
+            >
+              <Pagination.Basic
+                data={data}
+                dotStyle={{ backgroundColor: c.grey1, borderRadius: 100 }}
+                activeDotStyle={{ backgroundColor: c.grey2, borderRadius: 100 }}
+                containerStyle={{
+                  gap: s.$2,
+                }}
+                progress={progress}
+                horizontal
+              />
+            </View>
+
+            <View
+              style={{
+                paddingHorizontal: s.$2,
+                width: '100%',
+              }}
+            >
+              {index === data.length - 1 ? (
+                <Button variant="raised" title={"I'm ready"} onPress={() => done()} />
+              ) : (
+                <Button variant="raised" title="Next" onPress={() => nextSlide(index)} />
+              )}
+            </View>
+          </YStack>
         )}
       />
     </View>

--- a/features/onboarding/onboarding-screen.tsx
+++ b/features/onboarding/onboarding-screen.tsx
@@ -35,7 +35,7 @@ export function OnboardingScreen() {
           <YStack
             style={{
               height: '100%',
-              paddingTop: s.$4,
+              paddingTop: s.$2,
               paddingBottom: s.$4,
             }}
           >

--- a/ui/OnboardingCarouselItem.tsx
+++ b/ui/OnboardingCarouselItem.tsx
@@ -1,109 +1,56 @@
-import React from 'react'
 import { Heading } from './typo/Heading'
-import { XStack, YStack } from './core/Stacks'
 import { View } from 'react-native'
-import { useItemStore } from '@/features/pocketbase'
 import { ExampleGrid } from './grid/ExampleGrid'
 import { DetailsDemo } from './display/DetailsDemo'
 import { SearchDemo } from './display/SearchDemo'
-import { Button } from './buttons/Button'
-import { s, c } from '@/features/style/index'
+import { s } from '@/features/style'
 
-export const OnboardingCarouselItem = ({
-  index,
-  next,
-  onAddItem,
-  done,
-  children,
-}: {
-  index: number
-  next: () => void
-  onAddItem?: () => void
-  done: () => void
-  children: React.ReactNode
-}) => {
-  const { items } = useItemStore()
-
+const OnboardingCarouselHeading = ({ index }: { index: number }) => {
   if (index === 0)
     return (
-      <View
-        style={{
-          flex: 1,
-          marginHorizontal: s.$08,
-          justifyContent: 'center',
-        }}
-      >
-        <YStack gap={s.$4}>
-          <View style={{ height: 100, justifyContent: 'flex-end' }}>
-            <Heading tag="h2" style={{ textAlign: 'center' }}>
-              This is a grid.{'\n'} {'\n'}{' '}
-              <Heading tag="h2normal">
-                A mural that makes you, <Heading tag="h2normalitalic">you</Heading>
-              </Heading>
-            </Heading>
-          </View>
-          <ExampleGrid />
-          <View style={{ height: 100, justifyContent: 'center' }}>{children}</View>
-        </YStack>
-
-        <View
-          style={{ paddingHorizontal: s.$2, position: 'absolute', bottom: s.$3, width: '100%' }}
-        >
-          <Button variant="raised" title="Next" onPress={next} />
-        </View>
-      </View>
+      <Heading tag="h2" style={{ textAlign: 'center' }}>
+        This is a grid.{'\n'} {'\n'}{' '}
+        <Heading tag="h2normal">
+          A mural that makes you, <Heading tag="h2normalitalic">you</Heading>
+        </Heading>
+      </Heading>
     )
-
   if (index === 1)
     return (
-      <View
-        style={{
-          flex: 1,
-          justifyContent: 'center',
-        }}
-      >
-        <YStack gap={s.$4}>
-          <View style={{ height: 100, justifyContent: 'flex-end' }}>
-            <Heading tag="h2normal" style={{ textAlign: 'center' }}>
-              <Heading tag="h2">Fill your grid</Heading> with links, photos, hobbies, places.
-            </Heading>
-          </View>
-          <DetailsDemo />
-          <View style={{ height: 100, justifyContent: 'center' }}>{children}</View>
-        </YStack>
-
-        <View
-          style={{ paddingHorizontal: s.$2, position: 'absolute', bottom: s.$3, width: '100%' }}
-        >
-          <Button variant="raised" title="Next" onPress={next} />
-        </View>
-      </View>
+      <Heading tag="h2normal" style={{ textAlign: 'center' }}>
+        <Heading tag="h2">Fill your grid</Heading> with links, photos, hobbies, places.
+      </Heading>
     )
-
-  if (index === 2)
+  else {
     return (
+      <Heading tag="h2normal" style={{ textAlign: 'center' }}>
+        ...then <Heading tag="h2">find people</Heading> based on the{'\n'}refs they add
+      </Heading>
+    )
+  }
+}
+
+const OnboardingCarouselContent = ({ index }: { index: number }) => {
+  if (index === 0) return <ExampleGrid />
+  if (index === 1) return <DetailsDemo />
+  if (index === 2) return <SearchDemo />
+}
+
+export const OnboardingCarouselItem = ({ index }: { index: number }) => {
+  return (
+    <>
       <View
         style={{
-          flex: 1,
-          marginHorizontal: s.$08,
-          justifyContent: 'center',
+          justifyContent: 'flex-end',
+          paddingTop: s.$8,
+          paddingBottom: s.$4,
         }}
       >
-        <YStack gap={s.$4}>
-          <View style={{ height: 100, justifyContent: 'flex-end' }}>
-            <Heading tag="h2normal" style={{ textAlign: 'center' }}>
-              ...then <Heading tag="h2">find people</Heading> based on the{'\n'}refs they add
-            </Heading>
-          </View>
-          <SearchDemo />
-          <View style={{ height: 100, justifyContent: 'center' }}>{children}</View>
-        </YStack>
-
-        <View
-          style={{ paddingHorizontal: s.$2, position: 'absolute', bottom: s.$3, width: '100%' }}
-        >
-          <Button variant="raised" title="I'm ready" onPress={done} />
-        </View>
+        <OnboardingCarouselHeading index={index} />
       </View>
-    )
+      <View style={{ flexGrow: 1 }}>
+        <OnboardingCarouselContent index={index} />
+      </View>
+    </>
+  )
 }

--- a/ui/display/DetailsDemo.tsx
+++ b/ui/display/DetailsDemo.tsx
@@ -45,8 +45,7 @@ export const DetailsDemo = () => {
     <View
       pointerEvents="none"
       style={{
-        width: win.width,
-        height: win.width,
+        height: win.width + 50,
         overflow: 'hidden',
         left: 0,
       }}

--- a/ui/display/SearchDemo.tsx
+++ b/ui/display/SearchDemo.tsx
@@ -191,6 +191,7 @@ const styles = StyleSheet.create({
     width: win.width - s.$2,
     overflow: 'hidden',
     height: win.width - s.$2,
+    marginHorizontal: 'auto',
     // Replicating the transform from the Svelte code:
     // transform: [{ translateX: 10 }, { translateY: 12 }],
   },

--- a/ui/grid/ExampleGrid.tsx
+++ b/ui/grid/ExampleGrid.tsx
@@ -1,40 +1,40 @@
-import { YStack, XStack } from '@/ui'
-import { GridTile } from './GridTile'
 import { GridTileImage } from './GridTileImage'
-import { GridTileList } from './GridTileList'
 import { GridItem } from './GridItem'
 import { GridWrapper } from './GridWrapper'
 import { GridTileWrapper } from './GridTileWrapper'
+import { View } from 'react-native'
 
 export const ExampleGrid = () => (
-  <GridWrapper columns={3} rows={3}>
-    <GridTileWrapper canEdit={false} type="image">
-      <GridTileImage source={require('@/assets/1.png')} />
-    </GridTileWrapper>
-    <GridTileWrapper canEdit={false} type="image">
-      <GridTileImage source={require('@/assets/2.png')} />
-    </GridTileWrapper>
-    <GridTileWrapper canEdit={false} type="image">
-      <GridTileImage source={require('@/assets/3.png')} />
-    </GridTileWrapper>
-    <GridTileWrapper canEdit={false} type="image">
-      <GridTileImage source={require('@/assets/4.png')} />
-    </GridTileWrapper>
-    <GridTileWrapper canEdit={false} type="text">
-      <GridItem item={{ expand: { ref: { title: 'chinatown dumpling tier list' } } }} i={0} />
-      {/* <GridTileList title="chinatown dumpling tier list" /> */}
-    </GridTileWrapper>
-    <GridTileWrapper canEdit={false} type="image">
-      <GridTileImage source={require('@/assets/6.png')} />
-    </GridTileWrapper>
-    <GridTileWrapper canEdit={false} type="image">
-      <GridTileImage source={require('@/assets/7.png')} />
-    </GridTileWrapper>
-    <GridTileWrapper canEdit={false} type="image">
-      <GridTileImage source={require('@/assets/8.png')} />
-    </GridTileWrapper>
-    <GridTileWrapper canEdit={false} type="text">
-      <GridItem item={{ expand: { ref: { title: '2025 reading list' } } }} i={0} />
-    </GridTileWrapper>
-  </GridWrapper>
+  <View style={{ marginHorizontal: 'auto' }}>
+    <GridWrapper columns={3} rows={3}>
+      <GridTileWrapper canEdit={false} type="image">
+        <GridTileImage source={require('@/assets/1.png')} />
+      </GridTileWrapper>
+      <GridTileWrapper canEdit={false} type="image">
+        <GridTileImage source={require('@/assets/2.png')} />
+      </GridTileWrapper>
+      <GridTileWrapper canEdit={false} type="image">
+        <GridTileImage source={require('@/assets/3.png')} />
+      </GridTileWrapper>
+      <GridTileWrapper canEdit={false} type="image">
+        <GridTileImage source={require('@/assets/4.png')} />
+      </GridTileWrapper>
+      <GridTileWrapper canEdit={false} type="text">
+        <GridItem item={{ expand: { ref: { title: 'chinatown dumpling tier list' } } }} i={0} />
+        {/* <GridTileList title="chinatown dumpling tier list" /> */}
+      </GridTileWrapper>
+      <GridTileWrapper canEdit={false} type="image">
+        <GridTileImage source={require('@/assets/6.png')} />
+      </GridTileWrapper>
+      <GridTileWrapper canEdit={false} type="image">
+        <GridTileImage source={require('@/assets/7.png')} />
+      </GridTileWrapper>
+      <GridTileWrapper canEdit={false} type="image">
+        <GridTileImage source={require('@/assets/8.png')} />
+      </GridTileWrapper>
+      <GridTileWrapper canEdit={false} type="text">
+        <GridItem item={{ expand: { ref: { title: '2025 reading list' } } }} i={0} />
+      </GridTileWrapper>
+    </GridWrapper>
+  </View>
 )


### PR DESCRIPTION
This PR fixes the issue where the text for the example refs in the onboarding carousel is being cut off. It also cleans up the code for displaying the onboarding, now each page is a single YStack (i.e. flex box) which makes it easier to ensure that the content section expands to fill the whole screen and that the footer (the pagination bar and the next button) always stay in the same place.

![Screenshot 2025-03-26 at 5 42 54 PM](https://github.com/user-attachments/assets/8220865b-171a-42dd-9ff7-8130d96c756e)
