### PR TITLE
expand area that causes text input in newref form to close

### DIFF
--- a/ui/actions/NewRef.tsx
+++ b/ui/actions/NewRef.tsx
@@ -100,7 +100,7 @@ export const NewRef = ({
   }, [step])
 
   return (
-    <>
+    <View style={{ paddingHorizontal: s.$2 }}>
       {step === '' && (
         <YStack gap={s.$08} style={{ paddingTop: s.$1, paddingBottom: s.$6 }}>
           <Button
@@ -180,6 +180,6 @@ export const NewRef = ({
           }}
         />
       )}
-    </>
+    </View>
   )
 }

--- a/ui/profiles/Profile.tsx
+++ b/ui/profiles/Profile.tsx
@@ -252,7 +252,7 @@ export const Profile = ({ userName }: { userName: string }) => {
       )}
 
       {(addingTo === 'grid' || addingTo === 'backlog') && (
-        <Sheet full={step !== ''} onChange={(e) => e === -1 && setAddingTo('')}>
+        <Sheet noPadding={true} full={step !== ''} onChange={(e) => e === -1 && setAddingTo('')}>
           <NewRef
             backlog={addingTo === 'backlog'}
             onStep={setStep}


### PR DESCRIPTION
We have an issue in the new ref form, where if we have the keyboard open on the "Add a caption for your profile" field, we can only unfocus it if we tap on a specific area (marked in blue):
![Screenshot 2025-03-31 at 10 45 22 AM](https://github.com/user-attachments/assets/cb5aeb34-59bc-4aa4-8526-164fe929c9f9)

We can improve the UX by expanding the tappable area to the blue and pink areas as shown below:
![Screenshot 2025-03-31 at 10 52 49 AM](https://github.com/user-attachments/assets/f2c21ba0-0ce2-4edc-bafe-d2ec3e1bb77c)
