### PR TITLE
don't autocorrect email, password or name in signup/login forms

### DIFF
--- a/app/user/login.tsx
+++ b/app/user/login.tsx
@@ -58,6 +58,7 @@ const EmailStep = ({ carouselRef }: { carouselRef: React.RefObject<ICarouselInst
             placeholder={'Login with email'}
             value={value}
             autoFocus={false}
+            autoCorrect={false}
           />
         )}
       />
@@ -115,6 +116,7 @@ const LoginStep = () => {
               placeholder="Password"
               value={value}
               autoFocus={false}
+              autoCorrect={false}
             />
           )
         }}

--- a/ui/inputs/FormFieldWithIcon.tsx
+++ b/ui/inputs/FormFieldWithIcon.tsx
@@ -14,6 +14,7 @@ export const FormFieldWithIcon = ({
   value = '',
   autoFocus = false,
   onBlur,
+  autoCorrect = true,
 }: {
   type:
     | 'email'
@@ -32,6 +33,7 @@ export const FormFieldWithIcon = ({
   onBlur: () => void
   value: string
   autoFocus: boolean
+  autoCorrect?: boolean
 }) => {
   const [showPassword, setShowPassword] = useState(false)
   const onSelect = (s: string) => {}
@@ -84,6 +86,7 @@ export const FormFieldWithIcon = ({
           onBlur={onBlur}
           onChangeText={onChange}
           value={value}
+          autoCorrect={autoCorrect}
           keyboardType={type === 'email' ? 'email-address' : 'default'}
         />
       </XStack>

--- a/ui/profiles/NewUserProfile.tsx
+++ b/ui/profiles/NewUserProfile.tsx
@@ -70,6 +70,7 @@ const EmailStep = ({ carouselRef }: { carouselRef: React.RefObject<ICarouselInst
             placeholder={'Sign up with email'}
             value={value}
             autoFocus={false}
+            autoCorrect={false}
           />
         )}
       />
@@ -114,6 +115,7 @@ const NameStep = ({ carouselRef }: { carouselRef: React.RefObject<ICarouselInsta
             placeholder={'First Name'}
             value={value}
             autoFocus={false}
+            autoCorrect={false}
           />
         )}
       />
@@ -133,6 +135,7 @@ const NameStep = ({ carouselRef }: { carouselRef: React.RefObject<ICarouselInsta
             placeholder={'Last Name'}
             value={value}
             autoFocus={false}
+            autoCorrect={false}
           />
         )}
       />
@@ -225,6 +228,7 @@ const PasswordStep = ({ carouselRef }: { carouselRef: React.RefObject<ICarouselI
             value={value}
             autoFocus={false}
             onBlur={onBlur}
+            autoCorrect={false}
           />
         )}
       />
@@ -245,6 +249,7 @@ const PasswordStep = ({ carouselRef }: { carouselRef: React.RefObject<ICarouselI
             value={value}
             autoFocus={false}
             onBlur={onBlur}
+            autoCorrect={false}
           />
         )}
       />


### PR DESCRIPTION
Managed to finally reproduce this. PR updates the email, password and name fields in the signup and login forms to *disable* autocorrect.