### PR TITLE
fix CI timeout: disable tests in ci because we don't have any

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,5 +23,6 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
-      - name: Run tests
-        run: yarn test
+      # Commented out for now as we don't have any tests yet
+      # - name: Run tests
+      #   run: yarn test


### PR DESCRIPTION
We don't have any automated tests right now, so the test runner hangs for six hours (!) every time CI runs. This PR comments out that part of the CI so that this doesn't happen.