### PR TITLE
More small fixes

### DIFF
--- a/features/home/nearby.tsx
+++ b/features/home/nearby.tsx
@@ -43,7 +43,7 @@ const ListItem = ({ item }: { item: ExpandedItem }) => {
               }}
             />
           ) : (
-            <Ionicons name="person" size={42} color={c.accent} />
+            <Ionicons name="person" size={s.$5} color={c.accent} />
           )}
         </Link>
       )}

--- a/features/home/nearby.tsx
+++ b/features/home/nearby.tsx
@@ -15,8 +15,8 @@ const ListItem = ({ item }: { item: ExpandedItem }) => {
 
   const creatorProfileUrl = createdByCurrentUser
     ? ('/' as const)
-    : (`/user/${creator.userName}` as const)
-  const itemUrl = `${creatorProfileUrl}/modal?initialId=${item.id}` as const
+    : (`/user/${creator.userName}/` as const)
+  const itemUrl = `${creatorProfileUrl}modal?initialId=${item.id}` as const
 
   return (
     <XStack
@@ -62,16 +62,18 @@ const ListItem = ({ item }: { item: ExpandedItem }) => {
       </View>
 
       {item?.image ? (
-        <SimplePinataImage
-          originalSource={item.image}
-          imageOptions={{ width: s.$5, height: s.$5 }}
-          style={{
-            width: s.$5,
-            height: s.$5,
-            backgroundColor: c.accent,
-            borderRadius: s.$075,
-          }}
-        />
+        <Link href={item.expand?.creator ? (item.backlog ? creatorProfileUrl : itemUrl) : '/'}>
+          <SimplePinataImage
+            originalSource={item.image}
+            imageOptions={{ width: s.$5, height: s.$5 }}
+            style={{
+              width: s.$5,
+              height: s.$5,
+              backgroundColor: c.accent,
+              borderRadius: s.$075,
+            }}
+          />
+        </Link>
       ) : (
         <View
           style={{

--- a/ui/actions/RefForm.tsx
+++ b/ui/actions/RefForm.tsx
@@ -169,7 +169,7 @@ export const RefForm = ({
       )}
 
       <EditableHeader
-        onComplete={handleTitleChange}
+        onTitleChange={handleTitleChange}
         onDataChange={handleDataChange}
         placeholder={placeholder}
         title={title || placeholder}

--- a/ui/profiles/Details.tsx
+++ b/ui/profiles/Details.tsx
@@ -31,6 +31,7 @@ export const renderItem = ({
   editingRights?: boolean
   index: number
 }) => {
+  const { updateOne } = useRefStore()
   const [editing, setEditing] = useState(false)
   const [title, setTitle] = useState(item.expand?.ref.title)
 

--- a/ui/profiles/NewUserProfile.tsx
+++ b/ui/profiles/NewUserProfile.tsx
@@ -8,11 +8,10 @@ import Carousel, { ICarouselInstance } from 'react-native-reanimated-carousel'
 import { ProfileStep } from '@/ui/profiles/ProfileStep'
 import { Controller, useForm } from 'react-hook-form'
 import { ErrorView, FormFieldWithIcon } from '../inputs/FormFieldWithIcon'
-import { SizableText } from '..'
 import { DeviceLocation } from '../inputs/DeviceLocation'
 import { AvatarPicker } from '../inputs/AvatarPicker'
 import { FirstVisitScreen } from './FirstVisitScreen'
-
+import { SizableText } from '../typo/SizableText'
 const win = Dimensions.get('window')
 
 const EmailStep = ({ carouselRef }: { carouselRef: React.RefObject<ICarouselInstance> }) => {


### PR DESCRIPTION
- [x] Fix a circular import from `NewUserProfile`
- [x] Clicking on an image in the feed should bring you to the ref's page
- [x] Updating the ref's title sometimes throws an error, this is because the `onTitleChange` prop had the wrong name in `RefForm`
- [x] Add a missing call to `useRefStore` in `Details.tsx`
- [x] Align user icons and the placeholder user icon in feed