### PR TITLE
Load thumbnails, fix bug when displaying an image without a placeholder

### DIFF
--- a/features/pinata/index.ts
+++ b/features/pinata/index.ts
@@ -32,6 +32,14 @@ export const getPinataImage = async (url: string, imageOptions: OptimizeImageOpt
   return url
 }
 
+export const constructPinataUrl = (url: string, imageOptions: OptimizeImageOptions) => {
+  const cid = /files\/(.*)(?:\?)/g.exec(url)
+
+  if (!cid?.[1] || !imageOptions?.width || !imageOptions?.height) return url
+
+  return `https://violet-fashionable-blackbird-836.mypinata.cloud/files/${cid[1]}?img-width=${imageOptions.width}&img-height=${imageOptions.height}`
+}
+
 /**
  * Create a signed pinata url
  */

--- a/features/pocketbase/stores/images.ts
+++ b/features/pocketbase/stores/images.ts
@@ -9,6 +9,10 @@ export type OptimizeImageOptions = {
 type SignedUrlEntry = { expires: number; date: number; signedUrl: string }
 type SignedUrls = Record<string, SignedUrlEntry>
 
+// when we load a view with a lot of images, we have a lot of async requests
+// this is a pool of promises that we can use to store the promises for each image
+// so that if we request the same image twice, we don't make two requests
+// we can just wait for the first promise to resolve and then use that result for the second request
 type PromisePool = MutableRefObject<Record<string, Promise<SignedUrlEntry>>>
 const promisePool = createRef<Record<string, Promise<SignedUrlEntry>>>() as PromisePool
 promisePool.current = {}

--- a/features/pocketbase/stores/images.ts
+++ b/features/pocketbase/stores/images.ts
@@ -1,0 +1,89 @@
+import { createRef, MutableRefObject } from 'react'
+import { create } from 'zustand'
+
+export type OptimizeImageOptions = {
+  width: number
+  height: number
+}
+
+type SignedUrlEntry = { expires: number; date: number; signedUrl: string }
+type SignedUrls = Record<string, SignedUrlEntry>
+
+type PromisePool = MutableRefObject<Record<string, Promise<SignedUrlEntry>>>
+const promisePool = createRef<Record<string, Promise<SignedUrlEntry>>>() as PromisePool
+promisePool.current = {}
+
+async function getSignedUrlRequest(url: string): Promise<SignedUrlEntry> {
+  const date = Date.now()
+  const expires = 500000
+
+  const options = {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${process.env.EXPO_PUBLIC_PIN_JWT}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      url,
+      expires,
+      date,
+      method: 'GET',
+    }),
+  }
+
+  try {
+    const response = await fetch('https://api.pinata.cloud/v3/files/sign', options)
+    const value = await response.json()
+    return { date, expires, signedUrl: value.data as string }
+  } catch (error) {
+    console.error(error)
+    throw error
+  }
+}
+
+export const useImageStore = create<{
+  promisePool: PromisePool
+  signedUrls: SignedUrls
+  pendingSignedUrlRequests: Record<string, Promise<SignedUrlEntry>>
+  getSignedUrl: (url: string) => Promise<string>
+}>((set, get) => ({
+  promisePool,
+  signedUrls: {},
+  pendingSignedUrlRequests: {},
+  getSignedUrl: async (url: string) => {
+    // try to get the cached signed url
+    const cachedSignedUrl = get().signedUrls[url]
+
+    // if it exists and is not expired, then return it
+    if (cachedSignedUrl) {
+      const isExpired = cachedSignedUrl.expires + cachedSignedUrl.date > Date.now()
+      if (!isExpired) {
+        return cachedSignedUrl.signedUrl
+      }
+    }
+
+    const currentPromisePool = get().promisePool.current
+    const cachedPromise = currentPromisePool[url]
+
+    let promiseToAwait: Promise<SignedUrlEntry>
+    if (cachedPromise) {
+      promiseToAwait = cachedPromise
+    } else {
+      promiseToAwait = getSignedUrlRequest(url)
+      currentPromisePool[url] = promiseToAwait
+    }
+
+    const signedUrlEntry = await promiseToAwait
+
+    set((state) => ({
+      signedUrls: {
+        ...state.signedUrls,
+        [url]: signedUrlEntry,
+      },
+    }))
+
+    delete currentPromisePool[url]
+
+    return signedUrlEntry.signedUrl
+  },
+}))

--- a/features/pocketbase/stores/items.ts
+++ b/features/pocketbase/stores/items.ts
@@ -38,7 +38,7 @@ export const useItemStore = create<{
   setSearchingNewRef: (id: string) => set(() => ({ searchingNewRef: id })),
   stopEditing: () =>
     set(() => {
-      return { editing: '', editedState: {}, setSearchingNewRef: '' }
+      return { editing: '', editedState: {}, searchingNewRef: '' }
     }),
   updateEditedState: (editedState: Partial<CompleteRef>) =>
     set(() => ({

--- a/ui/images/SimplePinataImage.tsx
+++ b/ui/images/SimplePinataImage.tsx
@@ -1,6 +1,32 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import { Image, type ImageProps } from 'expo-image'
-import { getPinataImage, type OptimizeImageOptions } from '@/features/pinata'
+import { constructPinataUrl, type OptimizeImageOptions } from '@/features/pinata'
+import { useImageStore } from '@/features/pocketbase/stores/images'
+import { View } from 'react-native'
+
+function useSignedImageUrl(originalSource: string, imageOptions: OptimizeImageOptions) {
+  const [loading, setLoading] = useState(true)
+  const [source, setSource] = useState<string | null>(null)
+  const { getSignedUrl, signedUrls } = useImageStore()
+
+  const url = useMemo(
+    () => constructPinataUrl(originalSource, imageOptions),
+    [originalSource, imageOptions]
+  )
+
+  useEffect(() => {
+    getSignedUrl(url)
+  }, [url])
+
+  useEffect(() => {
+    if (signedUrls[url]) {
+      setSource(signedUrls[url].signedUrl)
+      setLoading(false)
+    }
+  }, [signedUrls[url]])
+
+  return { source, loading }
+}
 
 export const SimplePinataImage = ({
   originalSource,
@@ -14,40 +40,15 @@ export const SimplePinataImage = ({
   placeholderContentFit?: ImageProps['contentFit']
   imageOptions: OptimizeImageOptions
 } & Omit<ImageProps, 'source'>) => {
-  const [loading, setLoading] = useState(true)
-  const [source, setSource] = useState('')
-
-  useEffect(() => {
-    // Reset loading state when original source changes
-    setLoading(true)
-
-    const load = async () => {
-      if (originalSource.includes('pinata')) {
-        setSource(originalSource)
-        setLoading(false)
-      } else {
-        try {
-          const newSource = await getPinataImage(originalSource, imageOptions)
-          setSource(newSource)
-          setLoading(false)
-        } catch (error) {
-          console.error(error)
-          // Fall back to placeholder or original source on error
-          setSource(placeholder || originalSource)
-          setLoading(false)
-        }
-      }
-    }
-
-    load()
-  }, [originalSource, imageOptions])
-
+  const { source, loading } = useSignedImageUrl(originalSource, imageOptions)
   // Always render an image - either the placeholder during loading or the final source
-  return (
+  return loading ? (
+    <View />
+  ) : (
     <Image
       {...props}
       contentFit={loading ? placeholderContentFit : 'cover'}
-      source={loading && placeholder ? placeholder : source || placeholder || originalSource}
+      source={source || placeholder || originalSource}
     />
   )
 }


### PR DESCRIPTION
This PR aims to make images load faster:

- Pinata lets us request images in a particular size, which enables to save a lot of bandwidth because we basically never display images at their full size: https://docs.pinata.cloud/gateways/image-optimizations
- To display an image we need a signed URL, which is created by making an async request to the Pinata API. If we want to display the same image a lot of times (e.g. when displaying user profile pictures) then just make one request. We can do this by creating a ref and storing it in Zustand, which is then shared between all the components that display images. Also, if we we've generated the signed URL for an image in the past, we should just use the saved value.
- There was a bug where the expo-image `Image` component would take longer to load if the `source` argument was undefined and then becomes not undefined (e.g when waiting for the signed URL). I updated `SimplePinataImage` so that if the `source` field is undefined, then just display an empty `View`. For some reason this sped up the feed a lot...