### PR TITLE
fix pnpm version mismatch in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4.0.0
-        with:
-          version: 10.8.0
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4.0.0
         with:
-          version: 10
+          version: 10.8.0
 
       - name: Install dependencies
         run: pnpm install


### PR DESCRIPTION
The issue here is that we are specifying the pnpm version to run in CI in two places: `package.json` and `.github/workflows/ci.yml`. We don't have to specify it in the CI config, see https://github.com/pnpm/action-setup?tab=readme-ov-file#version