### PR TITLE
bugfix: in the feed, only show items that are in users' profiles

### DIFF
--- a/features/home/feed.tsx
+++ b/features/home/feed.tsx
@@ -41,6 +41,8 @@ export const Feed = () => {
     const getInitialData = async () => {
       try {
         const records = await pocketbase.collection('items').getList<ExpandedItem>(1, 30, {
+          // TODO: remove list = false once we have a way to display lists in the feed
+          // also consider showing backlog items in the feed, when we have a way to link to them
           filter: `creator != null && backlog = false && list = false`,
           sort: '-created',
           expand: 'ref,creator',

--- a/features/home/feed.tsx
+++ b/features/home/feed.tsx
@@ -41,7 +41,7 @@ export const Feed = () => {
     const getInitialData = async () => {
       try {
         const records = await pocketbase.collection('items').getList<ExpandedItem>(1, 30, {
-          filter: `creator != null && backlog = false`,
+          filter: `creator != null && backlog = false && list = false`,
           sort: '-created',
           expand: 'ref,creator',
         })

--- a/features/home/feed.tsx
+++ b/features/home/feed.tsx
@@ -41,7 +41,7 @@ export const Feed = () => {
     const getInitialData = async () => {
       try {
         const records = await pocketbase.collection('items').getList<ExpandedItem>(1, 30, {
-          filter: `creator != null`,
+          filter: `creator != null && backlog = false`,
           sort: '-created',
           expand: 'ref,creator',
         })

--- a/features/home/nearby.tsx
+++ b/features/home/nearby.tsx
@@ -42,14 +42,14 @@ const ListItem = ({ item }: { item: ExpandedItem }) => {
           <Heading style={{ color: c.muted2 }} tag="p">
             added{' '}
           </Heading>
-          <Link href={item.expand?.creator ? (item.backlog ? creatorProfileUrl : itemUrl) : '/'}>
+          <Link href={item.expand?.creator ? itemUrl : '/'}>
             <Heading tag="semistrong">{item.expand?.ref?.title}</Heading>
           </Link>
         </Heading>
       </View>
 
       {item?.image ? (
-        <Link href={item.expand?.creator ? (item.backlog ? creatorProfileUrl : itemUrl) : '/'}>
+        <Link href={item.expand?.creator ? itemUrl : '/'}>
           <SimplePinataImage
             originalSource={item.image}
             imageOptions={{ width: s.$5, height: s.$5 }}
@@ -76,7 +76,6 @@ const ListItem = ({ item }: { item: ExpandedItem }) => {
 }
 
 export const Nearby = ({ items }: { items: ExpandedItem[] }) => {
-  const itemsWithoutBacklog = items.filter((item) => !item.backlog)
   return (
     <View
       style={{
@@ -98,7 +97,7 @@ export const Nearby = ({ items }: { items: ExpandedItem[] }) => {
           paddingBottom: s.$12,
         }}
       >
-        {itemsWithoutBacklog.map((item) => (
+        {items.map((item) => (
           <ListItem key={item.id} item={item} />
         ))}
       </YStack>

--- a/features/home/nearby.tsx
+++ b/features/home/nearby.tsx
@@ -76,6 +76,7 @@ const ListItem = ({ item }: { item: ExpandedItem }) => {
 }
 
 export const Nearby = ({ items }: { items: ExpandedItem[] }) => {
+  const itemsWithoutBacklog = items.filter((item) => !item.backlog)
   return (
     <View
       style={{
@@ -97,7 +98,7 @@ export const Nearby = ({ items }: { items: ExpandedItem[] }) => {
           paddingBottom: s.$12,
         }}
       >
-        {items.map((item) => (
+        {itemsWithoutBacklog.map((item) => (
           <ListItem key={item.id} item={item} />
         ))}
       </YStack>


### PR DESCRIPTION
Fixes https://github.com/refs-nyc/refs/issues/26

This PR filters items that are on the backlog out of the feed. It also filters out items that have "list = true".