### PR TITLE
replace backlog button on profile with new console

### DIFF
--- a/ui/profiles/BacklogBottomSheet.tsx
+++ b/ui/profiles/BacklogBottomSheet.tsx
@@ -1,0 +1,92 @@
+import { c, s } from '@/features/style'
+import BottomSheet, { BottomSheetBackdrop } from '@gorhom/bottom-sheet'
+import { useCallback, useRef, useState } from 'react'
+import { Pressable, View, Text } from 'react-native'
+import { Heading } from '../typo/Heading'
+import { XStack } from '../core/Stacks'
+
+export default function BacklogBottomSheet({
+  onAddToBacklogClick,
+}: {
+  onAddToBacklogClick: () => void
+}) {
+  const [index, setIndex] = useState(0)
+  const backlogSheetRef = useRef<BottomSheet>(null)
+
+  const renderBackdrop = useCallback(
+    (p: any) => (
+      <BottomSheetBackdrop
+        {...p}
+        disappearsOnIndex={0}
+        appearsOnIndex={1}
+        pressBehavior={'collapse'}
+      />
+    ),
+    []
+  )
+
+  return (
+    <BottomSheet
+      enableDynamicSizing={false}
+      ref={backlogSheetRef}
+      enablePanDownToClose={false}
+      snapPoints={['15%', '50%']}
+      onChange={(i: number) => setIndex(i)}
+      backgroundStyle={{ backgroundColor: c.olive, borderRadius: s.$4, paddingTop: 0 }}
+      backdropComponent={renderBackdrop}
+      handleIndicatorStyle={{
+        width: s.$13,
+        height: s.$075,
+        // display: index < 1 ? 'none' : 'flex',
+        backgroundColor: index < 1 ? 'transparent' : c.white,
+      }}
+    >
+      <Pressable
+        onPress={() => {
+          if (backlogSheetRef.current) backlogSheetRef.current.snapToIndex(1)
+        }}
+        style={{ height: s.$7 }}
+      >
+        <XStack
+          gap={s.$075}
+          style={{
+            alignItems: 'center',
+            justifyContent: 'center',
+            paddingHorizontal: s.$2,
+          }}
+        >
+          <Heading
+            tag="h2normal"
+            style={{
+              color: c.white,
+              // flex: 1,
+            }}
+          >
+            My Backlog
+          </Heading>
+          <View
+            style={{
+              height: 1,
+              flex: 1,
+              backgroundColor: c.white,
+            }}
+          ></View>
+          <Pressable
+            onPress={onAddToBacklogClick}
+            style={{
+              borderRadius: s.$10,
+              borderWidth: 1,
+              borderColor: c.white,
+              width: s.$3,
+              height: s.$3,
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <Text style={{ color: c.white, fontSize: s.$1, lineHeight: s.$1 }}>+</Text>
+          </Pressable>
+        </XStack>
+      </Pressable>
+    </BottomSheet>
+  )
+}

--- a/ui/profiles/BacklogBottomSheet.tsx
+++ b/ui/profiles/BacklogBottomSheet.tsx
@@ -37,7 +37,6 @@ export default function BacklogBottomSheet({
       handleIndicatorStyle={{
         width: s.$13,
         height: s.$075,
-        // display: index < 1 ? 'none' : 'flex',
         backgroundColor: index < 1 ? 'transparent' : c.white,
       }}
     >

--- a/ui/profiles/Profile.tsx
+++ b/ui/profiles/Profile.tsx
@@ -25,7 +25,7 @@ import {
 import { gridSort, createdSort } from '../profiles/sorts'
 import { DMButton } from './DMButton'
 import { useMessageStore } from '@/features/pocketbase/stores/messages'
-import { BottomSheetScrollView, BottomSheetView } from '@gorhom/bottom-sheet'
+import BacklogBottomSheet from './BacklogBottomSheet'
 
 const win = Dimensions.get('window')
 
@@ -181,18 +181,9 @@ export const Profile = ({ userName }: { userName: string }) => {
                     rows={4}
                   ></Grid>
                   {/* Actions */}
-                  <Pressable onPress={() => stopEditProfile()}>
-                    <XStack gap={s.$2} style={{ justifyContent: 'center', width: '100%' }}>
-                      {editingRights && (
-                        <Button
-                          onPress={() => setAddingTo('backlog')}
-                          variant="raisedSecondary"
-                          title="Backlog"
-                          iconColor={c.muted}
-                          iconAfter="add-circle-outline"
-                        />
-                      )}
-                      {showMessageButtons && (
+                  {showMessageButtons && (
+                    <Pressable onPress={() => stopEditProfile()}>
+                      <XStack gap={s.$2} style={{ justifyContent: 'center', width: '100%' }}>
                         <>
                           <DMButton profile={profile} />
                           <Button
@@ -204,9 +195,9 @@ export const Profile = ({ userName }: { userName: string }) => {
                             iconBefore="bookmark"
                           />
                         </>
-                      )}
-                    </XStack>
-                  </Pressable>
+                      </XStack>
+                    </Pressable>
+                  )}
                 </Animated.View>
               ) : (
                 <Animated.View
@@ -227,6 +218,14 @@ export const Profile = ({ userName }: { userName: string }) => {
           {!user && <Heading tag="h1">Profile for {userName} not found</Heading>}
         </YStack>
       </ScrollView>
+
+      {editingRights && (
+        <BacklogBottomSheet
+          onAddToBacklogClick={() => {
+            setAddingTo('backlog')
+          }}
+        />
+      )}
 
       {removingId && (
         <Sheet full={false} onChange={(e: any) => e === -1 && setRemovingId('')}>


### PR DESCRIPTION
This PR adds the new backlog console on the user's own profile. This replaces the Backlog + button. When it's expanded, it is mean to show the user's backlog items, this will be added in another PR. 

Closes #75 

<img src='https://github.com/user-attachments/assets/c97f6adb-4564-4fbe-bac1-569969abec43' width='200px'/>
<img src='https://github.com/user-attachments/assets/c848b2e5-2c5d-4176-a7b4-54ceaaf042ad' width='200px'/>
