### PR TITLE
Fix bug when app is restarted after user has already logged in

### DIFF
--- a/ui/navigation/Navigation.tsx
+++ b/ui/navigation/Navigation.tsx
@@ -20,9 +20,11 @@ export const Navigation = () => {
   const countNewMessages = () => {
     if (!user) return 0
     if (!messagesPerConversation) return 0
+    // messages not loaded yet
+    if (Object.keys(memberships).length === 0) return 0
     let newMessages = 0
     for (const conversationId in conversations) {
-      const lastRead = (memberships[conversationId] || []).find(
+      const lastRead = memberships[conversationId].find(
         (m) => m.expand?.user.id === user?.id
       )?.last_read
       const lastReadDate = new Date(lastRead || '')

--- a/ui/navigation/Navigation.tsx
+++ b/ui/navigation/Navigation.tsx
@@ -22,7 +22,7 @@ export const Navigation = () => {
     if (!messagesPerConversation) return 0
     let newMessages = 0
     for (const conversationId in conversations) {
-      const lastRead = memberships[conversationId].find(
+      const lastRead = (memberships[conversationId] || []).find(
         (m) => m.expand?.user.id === user?.id
       )?.last_read
       const lastReadDate = new Date(lastRead || '')


### PR DESCRIPTION
Fixes #106

The issue here is that the `countNewMessages` function is trying to count the number of new messages before the `memberships` state value has been updated. If `memberships` has not been loaded, we should just return `0`.