### PR TITLE
fix bug opening items from feed, don't use user store for profile items

### DIFF
--- a/app/settings/index.tsx
+++ b/app/settings/index.tsx
@@ -1,6 +1,15 @@
+import { useUserStore } from '@/features/pocketbase'
 import { SettingsScreen } from '@/features/settings/screen'
-import { Stack } from 'expo-router'
+import { useRouter } from 'expo-router'
 
 export default function Screen() {
+  const { user } = useUserStore()
+  const router = useRouter()
+
+  if (!user) {
+    router.dismissTo('/')
+    return
+  }
+
   return <SettingsScreen />
 }

--- a/features/home/nearby.tsx
+++ b/features/home/nearby.tsx
@@ -2,20 +2,14 @@ import { XStack, YStack, Heading } from '@/ui'
 import type { ExpandedItem } from '@/features/pocketbase/stores/types'
 import { Link } from 'expo-router'
 import { View, Dimensions } from 'react-native'
-import { useUserStore } from '@/features/pocketbase'
 import { s, c } from '@/features/style'
 import { SimplePinataImage } from '@/ui/images/SimplePinataImage'
 import { Avatar } from '@/ui/atoms/Avatar'
 const win = Dimensions.get('window')
 
 const ListItem = ({ item }: { item: ExpandedItem }) => {
-  const { user } = useUserStore()
   const creator = item.expand!.creator
-  const createdByCurrentUser = user && creator.userName === user?.userName
-
-  const creatorProfileUrl = createdByCurrentUser
-    ? ('/' as const)
-    : (`/user/${creator.userName}/` as const)
+  const creatorProfileUrl = `/user/${creator.userName}/` as const
   const itemUrl = `${creatorProfileUrl}modal?initialId=${item.id}` as const
 
   return (
@@ -30,26 +24,26 @@ const ListItem = ({ item }: { item: ExpandedItem }) => {
       }}
     >
       {item.expand?.creator && (
-        <Link dismissTo={creatorProfileUrl === '/'} href={creatorProfileUrl}>
+        <Link href={creatorProfileUrl}>
           <Avatar source={creator.image} size={s.$5} />
         </Link>
       )}
       <View style={{ overflow: 'hidden', flex: 1 }}>
         <Heading tag="p">
-          <Link dismissTo={creatorProfileUrl === '/'} href={creatorProfileUrl}>
+          <Link href={creatorProfileUrl}>
             <Heading tag="semistrong">{item.expand?.creator?.firstName || 'Anonymous'} </Heading>
           </Link>
           <Heading style={{ color: c.muted2 }} tag="p">
             added{' '}
           </Heading>
-          <Link href={item.expand?.creator ? itemUrl : '/'}>
+          <Link href={itemUrl}>
             <Heading tag="semistrong">{item.expand?.ref?.title}</Heading>
           </Link>
         </Heading>
       </View>
 
       {item?.image ? (
-        <Link href={item.expand?.creator ? itemUrl : '/'}>
+        <Link href={itemUrl}>
           <SimplePinataImage
             originalSource={item.image}
             imageOptions={{ width: s.$5, height: s.$5 }}

--- a/features/pocketbase/stores/users.ts
+++ b/features/pocketbase/stores/users.ts
@@ -10,20 +10,10 @@ export const isProfile = (profile: Profile | EmptyProfile | null): profile is Pr
   return profile !== null && Object.keys(profile).length > 0
 }
 
-export const isExpandedProfile = (
-  profile: ExpandedProfile | EmptyProfile
-): profile is ExpandedProfile => {
-  return Object.keys(profile).length > 0
-}
-
 export const useUserStore = create<{
   stagedUser: Partial<Profile>
   user: Profile | null
-  profile: Profile | EmptyProfile
-  profileItems: Item[]
-  backlogItems: Item[]
   register: () => Promise<ExpandedProfile>
-  getProfile: (userName: string) => Promise<ExpandedProfile>
   updateUser: (fields: Partial<Profile>) => Promise<Profile>
   updateStagedUser: (formFields: Partial<Profile>) => void
   attachItem: (itemId: string) => void
@@ -36,9 +26,6 @@ export const useUserStore = create<{
 }>((set, get) => ({
   stagedUser: {},
   user: null, // user is ALWAYS the user of the app, this is only set if the user is logged in
-  profile: {}, // profile can be any page you are currently viewing
-  profileItems: [],
-  backlogItems: [],
   users: [],
   //
   //
@@ -59,31 +46,6 @@ export const useUserStore = create<{
         // If we can't get the user record, clear the auth store
         pocketbase.authStore.clear()
       }
-    }
-  },
-  //
-  //
-  //
-  getProfile: async (userName: string) => {
-    try {
-      const record = await pocketbase
-        .collection('users')
-        .getFirstListItem<ExpandedProfile>(`userName = "${userName}"`, {
-          expand: 'items,items.ref,items.children',
-        })
-
-      set(() => ({
-        profile: record,
-        profileItems:
-          record?.expand?.items?.filter((itm: Item) => !itm.backlog).sort(gridSort) || [],
-        backlogItems:
-          record?.expand?.items?.filter((itm: Item) => itm.backlog).sort(createdSort) || [],
-      }))
-
-      return record
-    } catch (error) {
-      console.error(error)
-      throw error
     }
   },
   //

--- a/features/user/settings-screen.tsx
+++ b/features/user/settings-screen.tsx
@@ -1,31 +1,17 @@
-import { useEffect, useState } from 'react'
-import { pocketbase } from '@/features/pocketbase'
-import { Text, View } from 'react-native'
 import { router } from 'expo-router'
-import { Profile as ProfileType } from '@/features/pocketbase/stores/types'
 import { DeviceLocation } from '@/ui/inputs/DeviceLocation'
 import { FirstVisitScreen } from '@/ui/profiles/FirstVisitScreen'
 import { Button, ScreenWrapper } from '@/ui'
 import { useUserStore } from '@/features/pocketbase/stores/users'
 import { s } from '@/features/style'
 
-export function SettingsScreen({ userName }: { userName: string }) {
-  const { profile, getProfile, logout, updateUser } = useUserStore()
+export function SettingsScreen() {
+  const { logout, updateUser } = useUserStore()
 
   const handleLogout = async () => {
     await logout()
     router.push('/')
   }
-
-  useEffect(() => {
-    const load = async () => {
-      await getProfile(userName)
-
-      if (!pocketbase.authStore.isValid || ("id" in profile && pocketbase.authStore?.record?.id !== profile?.id))
-        router.push('/')
-    }
-    load()
-  }, [userName])
 
   return (
     <ScreenWrapper>

--- a/ui/profiles/Details.tsx
+++ b/ui/profiles/Details.tsx
@@ -1,22 +1,19 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react' // Import useCallback, useMemo
-import { Link, useGlobalSearchParams, usePathname, useRouter } from 'expo-router'
+import { useRouter } from 'expo-router'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
-import { View, Dimensions, Pressable, Text, ViewStyle, useWindowDimensions } from 'react-native'
+import { View, Dimensions, Pressable, ViewStyle } from 'react-native'
 import Carousel, { ICarouselInstance } from 'react-native-reanimated-carousel'
-import { c, s, t } from '@/features/style'
+import { c, s } from '@/features/style'
 import { gridSort } from './sorts'
-import Ionicons from '@expo/vector-icons/Ionicons'
 import { useItemStore } from '@/features/pocketbase/stores/items'
 import { SearchRef } from '../actions/SearchRef'
 import { EditableList } from '../lists/EditableList'
 import { Sheet, SheetScreen } from '../core/Sheets'
-import { useUserStore, isExpandedProfile } from '@/features/pocketbase/stores/users'
-import { ExpandedItem } from '@/features/pocketbase/stores/types'
+import { ExpandedItem, ExpandedProfile } from '@/features/pocketbase/stores/types'
 import { EditableItem } from './EditableItem' // Assuming EditableItem is memoized
 import { GridLines } from '../display/Gridlines'
 import { BottomSheetScrollView } from '@gorhom/bottom-sheet'
 import { MeatballMenu, Checkbox } from '../atoms/MeatballMenu'
-import { Button } from '../buttons/Button'
 import { useUIStore } from '@/ui/state'
 
 const win = Dimensions.get('window')
@@ -141,30 +138,24 @@ export const renderItem = ({
 }
 
 export const Details = ({
+  profile,
   editingRights = false,
   initialId,
 }: {
+  profile: ExpandedProfile
   editingRights?: boolean
   initialId: string
 }) => {
-  const { profile, getProfile } = useUserStore()
-  const { userName } = useGlobalSearchParams()
-
   const router = useRouter()
-  const pathname = usePathname()
   const ref = useRef<ICarouselInstance>(null)
 
   const { addingToList, setAddingToList, addingItem, setShowContextMenu } = useUIStore()
   const { stopEditing, update, editing: editingId } = useItemStore()
 
-  const userNameParam =
-    pathname === '/' ? undefined : typeof userName === 'string' ? userName : userName?.[0]
-
-  const data = useMemo(() => {
-    return isExpandedProfile(profile) && profile.expand?.items
-      ? [...profile.expand.items].filter((itm) => !itm.backlog).sort(gridSort)
-      : []
-  }, [profile])
+  const data = useMemo(
+    () => [...profile.expand.items].filter((itm) => !itm.backlog).sort(gridSort),
+    [profile]
+  )
 
   const index = useMemo(() => {
     return Math.max(
@@ -195,12 +186,9 @@ export const Details = ({
   const close = useCallback(async () => {
     setAddingToList('')
 
-    if (userNameParam) {
-      await getProfile(userNameParam)
-    }
     await update()
     stopEditing()
-  }, [setAddingToList, getProfile, userNameParam])
+  }, [setAddingToList])
 
   const carouselStyle = useMemo<{
     overflow: ViewStyle['overflow']

--- a/ui/profiles/Profile.tsx
+++ b/ui/profiles/Profile.tsx
@@ -43,7 +43,7 @@ export const Profile = ({ userName }: { userName: string }) => {
 
   const backlogSheetRef = useRef<BottomSheet>(null)
 
-  const { user, getProfile } = useUserStore()
+  const { user } = useUserStore()
   const { remove, moveToBacklog } = useItemStore()
 
   const setAddingTo = (str: string) => {
@@ -102,7 +102,6 @@ export const Profile = ({ userName }: { userName: string }) => {
   useEffect(() => {
     const init = async () => {
       try {
-        await getProfile(userName)
         await refreshGrid(userName)
         seteditingRights(pocketbase?.authStore?.record?.userName === userName)
         setShowMessageButtons(!(pocketbase?.authStore?.record?.userName === userName))


### PR DESCRIPTION
Fixes #97 

This fixes the bug where clicking on links to items in the feed sometimes opens an item belonging to the wrong user. Currently when we load an items carousel, we call `getProfile` from the users store which requests the corresponding user's profile data (and items) and saves it in `profile`, which is a global state variable managed by Zustand. We can simplify this code and exclude the possibility of displaying data from the wrong user by instead storing the items in a simple `useState` hook, which is then removed when we close the modal. I'm not totally sure which line of code was responsible originally, it might be something to do with the fact that the call to pocketbase is asynchronous. In any case this change removes the bug and a bit of complexity... 

This PR removes `profile` and `getProfile` from the user store.