### PR TITLE
Editing ref bugs

### DIFF
--- a/ui/actions/SearchRef.tsx
+++ b/ui/actions/SearchRef.tsx
@@ -121,7 +121,7 @@ export const SearchRef = ({
 
   return (
     <>
-      <KeyboardAvoidingView style={{ backgroundColor: 'yellow' }}>
+      <KeyboardAvoidingView>
         <TextInput
           style={{
             backgroundColor: c.surface2,

--- a/ui/actions/SearchRef.tsx
+++ b/ui/actions/SearchRef.tsx
@@ -1,17 +1,17 @@
 import { useState, useEffect } from 'react'
-import { pocketbase, useItemStore } from '@/features/pocketbase'
-import type { ExpandedItem } from '@/features/pocketbase/stores/types'
-import { Pressable, FlatList, KeyboardAvoidingView, View } from 'react-native'
+import { pocketbase } from '@/features/pocketbase'
+import { Pressable } from 'react-native'
 import { BottomSheetTextInput as TextInput } from '@gorhom/bottom-sheet'
 import { ListItem } from '@/ui/lists/ListItem'
 import { NewRefListItem } from '@/ui/atoms/NewRefListItem'
 import { YStack } from '@/ui/core/Stacks'
 import { s, c } from '@/features/style'
-import { CompleteRef, StagedRef, Item } from '../../features/pocketbase/stores/types'
-import { getLinkPreview, getPreviewFromContent } from 'link-preview-js'
+import { CompleteRef } from '../../features/pocketbase/stores/types'
+import { getLinkPreview } from 'link-preview-js'
 import { ShareIntent as ShareIntentType, useShareIntentContext } from 'expo-share-intent'
 import * as Clipboard from 'expo-clipboard'
 import { RefsRecord } from '@/features/pocketbase/stores/pocketbase-types'
+import { KeyboardAvoidingView } from 'react-native-keyboard-controller'
 
 export const SearchRef = ({
   noNewRef,
@@ -121,42 +121,44 @@ export const SearchRef = ({
 
   return (
     <>
-      <TextInput
-        style={{
-          backgroundColor: c.surface2,
-          marginVertical: s.$1,
-          paddingVertical: s.$1,
-          paddingHorizontal: s.$1,
-          borderRadius: s.$075,
-          color: c.black,
-        }}
-        clearButtonMode="while-editing"
-        value={searchQuery}
-        placeholder="Search anything or start typing"
-        onChangeText={updateQuery}
-        autoFocus={true}
-      />
+      <KeyboardAvoidingView style={{ backgroundColor: 'yellow' }}>
+        <TextInput
+          style={{
+            backgroundColor: c.surface2,
+            marginVertical: s.$1,
+            paddingVertical: s.$1,
+            paddingHorizontal: s.$1,
+            borderRadius: s.$075,
+            color: c.black,
+          }}
+          clearButtonMode="while-editing"
+          value={searchQuery}
+          placeholder="Search anything or start typing"
+          onChangeText={updateQuery}
+          autoFocus={false}
+        />
 
-      {searchQuery !== '' && !noNewRef && !disableNewRef && (
-        <Pressable
-          onPress={() => {
-            // @ts-ignore
-            return onComplete({ title: searchQuery, image: imageState, url: urlState })
+        {searchQuery !== '' && !noNewRef && !disableNewRef && (
+          <Pressable
+            onPress={() => {
+              // @ts-ignore
+              return onComplete({ title: searchQuery, image: imageState, url: urlState })
+            }}
+          >
+            {/* @ts-ignore */}
+            <NewRefListItem title={searchQuery} image={image} />
+          </Pressable>
+        )}
+        <YStack
+          style={{
+            flex: 1,
+            gap: s.$025,
+            minHeight: s.$12,
           }}
         >
-          {/* @ts-ignore */}
-          <NewRefListItem title={searchQuery} image={image} />
-        </Pressable>
-      )}
-      <YStack
-        style={{
-          flex: 1,
-          gap: s.$025,
-          minHeight: s.$12,
-        }}
-      >
-        {searchResults.map((r) => renderItem({ item: r }))}
-      </YStack>
+          {searchResults.map((r) => renderItem({ item: r }))}
+        </YStack>
+      </KeyboardAvoidingView>
     </>
   )
 }

--- a/ui/atoms/MeatballMenu.tsx
+++ b/ui/atoms/MeatballMenu.tsx
@@ -26,7 +26,7 @@ export const MeatballMenu = ({
   color = c.grey2,
   onPress,
 }: {
-  color: string
+  color?: string
   onPress: () => void
 }) => {
   return (

--- a/ui/atoms/MeatballMenu.tsx
+++ b/ui/atoms/MeatballMenu.tsx
@@ -7,13 +7,20 @@ export const Checkbox = ({ color = c.grey2, onPress }: { color?: string; onPress
     <Pressable
       onPress={onPress}
       style={{
-        width: s.$2,
-        height: s.$2,
+        width: s.$5,
+        height: s.$5,
+        borderRadius: s.$10,
         aspectRatio: 1,
-        // gap: 5,
         justifyContent: 'center',
         alignItems: 'center',
         backgroundColor: c.surface,
+        shadowColor: '#000',
+        shadowOffset: {
+          width: 1,
+          height: 5,
+        },
+        shadowOpacity: 0.25,
+        shadowRadius: 2,
       }}
     >
       <CheckboxIcon />
@@ -33,8 +40,8 @@ export const MeatballMenu = ({
     <Pressable
       onPress={onPress}
       style={{
-        width: s.$2,
-        height: s.$2,
+        width: s.$5,
+        height: s.$5,
         aspectRatio: 1,
         gap: 5,
         justifyContent: 'center',

--- a/ui/core/Sheets.tsx
+++ b/ui/core/Sheets.tsx
@@ -42,7 +42,10 @@ export const Sheet = (props: any = { full: false, noNotch: false, noPadding: fal
       onChange={props?.onChange}
       {...props}
     >
-      <BottomSheetScrollView showsVerticalScrollIndicator={false}>
+      <BottomSheetScrollView
+        keyboardShouldPersistTaps={props.keyboardShouldPersistTaps || "handled"}
+        showsVerticalScrollIndicator={false}
+      >
         {props?.children}
       </BottomSheetScrollView>
     </BottomSheet>

--- a/ui/profiles/Details.tsx
+++ b/ui/profiles/Details.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react' // Import useCallback, useMemo
 import { useRouter } from 'expo-router'
-import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { View, Dimensions, Pressable, ViewStyle } from 'react-native'
 import Carousel, { ICarouselInstance } from 'react-native-reanimated-carousel'
 import { c, s } from '@/features/style'
@@ -105,6 +104,7 @@ export const renderItem = ({
         <Sheet
           onClose={() => {
             console.log('close')
+            setSearchingNewRef('')
             // Do not update the ref
           }}
         >
@@ -204,6 +204,8 @@ export const Details = ({
         e === -1 && router.back()
         e === -1 && stopEditing()
       }}
+      snapPoints={['100%']}
+      maxDynamicContentSize={'100%'}
     >
       <ConditionalGridLines />
 

--- a/ui/profiles/Details.tsx
+++ b/ui/profiles/Details.tsx
@@ -102,6 +102,7 @@ export const renderItem = ({
 
       {searchingNewRef && (
         <Sheet
+          keyboardShouldPersistTaps="always"
           onClose={() => {
             console.log('close')
             setSearchingNewRef('')

--- a/ui/profiles/Details.tsx
+++ b/ui/profiles/Details.tsx
@@ -33,18 +33,7 @@ const DetailsHeaderButton = React.memo(({ item }: { item: ExpandedItem }) => {
   const editing = useItemStore((state) => state.editing)
   const update = useItemStore((state) => state.update)
   const stopEditing = useItemStore((state) => state.stopEditing)
-  const router = useRouter()
-  const insets = useSafeAreaInsets()
   const { setShowContextMenu } = useUIStore()
-
-  const handlePress = useCallback(async () => {
-    if (editing === '') {
-      router.back()
-    } else {
-      await update()
-      stopEditing()
-    }
-  }, [editing, router, stopEditing])
 
   return (
     <Pressable
@@ -55,17 +44,18 @@ const DetailsHeaderButton = React.memo(({ item }: { item: ExpandedItem }) => {
         alignItems: 'flex-end',
         top: s.$4,
       }}
-      onPress={handlePress}
+      onPress={() => {
+        setShowContextMenu('')
+      }}
     >
       {editing !== '' ? (
         <Checkbox
-          onPress={() => {
-            setShowContextMenu('')
+          onPress={async () => {
+            await update()
             stopEditing()
           }}
         />
       ) : (
-        // <Ionicons size={s.$1} name="checkbox" color={c.muted} />
         <MeatballMenu
           onPress={() => {
             setShowContextMenu(item.id)

--- a/ui/profiles/EditableItem.tsx
+++ b/ui/profiles/EditableItem.tsx
@@ -1,20 +1,19 @@
-import React, { useState, useEffect, useRef, forwardRef } from 'react'
+import React, { useState } from 'react'
 import { Image } from 'expo-image'
 import { Zoomable } from '@likashefqet/react-native-image-zoom'
 import { ContextMenu } from '../atoms/ContextMenu'
 import { useUIStore } from '@/ui/state'
 import { useItemStore } from '@/features/pocketbase/stores/items'
 import { ExpandedItem } from '@/features/pocketbase/stores/types'
-import { Href, Link } from 'expo-router'
-import { View, Pressable, Text, Dimensions } from 'react-native'
+import { Link } from 'expo-router'
+import { Pressable, Text, Dimensions } from 'react-native'
 import { Heading } from '../typo/Heading'
 import { c, s, t, base } from '@/features/style'
 import Ionicons from '@expo/vector-icons/Ionicons'
 import { ListContainer } from '../lists/ListContainer'
 import Animated, { useAnimatedStyle } from 'react-native-reanimated'
-import { BottomSheetTextInput, BottomSheetScrollView, BottomSheetView } from '@gorhom/bottom-sheet'
-import { Sheet } from '../core/Sheets'
-import { SearchRef } from '../actions/SearchRef'
+import { BottomSheetTextInput, BottomSheetView } from '@gorhom/bottom-sheet'
+import { KeyboardAvoidingView } from 'react-native-keyboard-controller'
 
 const win = Dimensions.get('window')
 
@@ -36,9 +35,13 @@ const EditableItemComponent = ({
   }, [editing, item])
 
   return (
-    <>
+    <KeyboardAvoidingView behavior={'position'}>
       <Pressable
-        style={{ gap: s.$09, paddingVertical: win.height * 0.1, paddingHorizontal: s.$2 }}
+        style={{
+          gap: s.$09,
+          paddingTop: win.height * 0.05,
+          paddingHorizontal: s.$2,
+        }}
         onPress={() => {
           setShowContextMenu('')
         }}
@@ -202,7 +205,7 @@ const EditableItemComponent = ({
           )}
         </Animated.View>
       </Pressable>
-    </>
+    </KeyboardAvoidingView>
   )
 }
 

--- a/ui/profiles/EditableItem.tsx
+++ b/ui/profiles/EditableItem.tsx
@@ -6,7 +6,7 @@ import { useUIStore } from '@/ui/state'
 import { useItemStore } from '@/features/pocketbase/stores/items'
 import { ExpandedItem } from '@/features/pocketbase/stores/types'
 import { Link } from 'expo-router'
-import { Pressable, Text, Dimensions } from 'react-native'
+import { Pressable, Text, Dimensions, Keyboard } from 'react-native'
 import { Heading } from '../typo/Heading'
 import { c, s, t, base } from '@/features/style'
 import Ionicons from '@expo/vector-icons/Ionicons'
@@ -127,7 +127,7 @@ const EditableItemComponent = ({
             <Pressable
               onPress={() => {
                 if (!editing) return
-
+                Keyboard.dismiss()
                 setSearchingNewRef(editing)
               }}
               style={[


### PR DESCRIPTION
This PR fixes a bunch of issues related to editing refs:
-bug where changes to the description wouldn't persist
-bug where clicking on the title to edit the ref only worked once, after which it became unresponsive
-refs in search results had to be pressed twice because the first tap just closed the keyboard
-other issues with keyboard handling / things being hidden behind the keyboard / modal randomly changing size 
-also updated checkbox to look like in the design

