### PR TITLE
fix bug when uploading images to new refs

### DIFF
--- a/features/pinata/index.ts
+++ b/features/pinata/index.ts
@@ -84,7 +84,8 @@ export const pinataUpload = async (
     const response = await fetch('https://uploads.pinata.cloud/v3/files', options)
     const result = await response.json()
 
-    const { signedUrl } = await pinataSignedUrl(result.data.cid)
+    const unsignedUrl = `https://violet-fashionable-blackbird-836.mypinata.cloud/files/${result.data.cid}`
+    const { signedUrl } = await pinataSignedUrl(unsignedUrl)
 
     return signedUrl
   } catch (error) {


### PR DESCRIPTION
Fixes #111

This PR fixes the bug where we were unable to upload new images - the problem was that I had changed the `pinataSignedUrl` function to take a URL as input instead of just a CID, but in one place we were still passing in the CID... 