### PR TITLE
Store both location and author for ref

### DIFF
--- a/features/pocketbase/stores/canvas.ts
+++ b/features/pocketbase/stores/canvas.ts
@@ -126,10 +126,10 @@ const refActions = {
     }
     this.db.set('ref', finalRef)
   },
-  async addRefMetadata(refId: string, { location, author }: { location: string; author: string }) {
+  async addRefMetadata(refId: string, meta: { meta: { location?: string; author?: string } }) {
     const ref = await this.db.get('ref', refId)
     if (!ref) return // TODO: ref might be missing id
-    this.db.set('ref', { ...ref, meta: { location, author } })
+    this.db.set('ref', { ...ref, meta })
   },
   async removeRef(refId: string) {
     this.db.delete('ref', refId)

--- a/features/pocketbase/stores/canvas.ts
+++ b/features/pocketbase/stores/canvas.ts
@@ -126,7 +126,7 @@ const refActions = {
     }
     this.db.set('ref', finalRef)
   },
-  async addRefMetadata(refId: string, meta: { meta: { location?: string; author?: string } }) {
+  async addRefMetadata(refId: string, { meta }: { meta: { location?: string; author?: string } }) {
     const ref = await this.db.get('ref', refId)
     if (!ref) return // TODO: ref might be missing id
     this.db.set('ref', { ...ref, meta })

--- a/features/pocketbase/stores/canvas.ts
+++ b/features/pocketbase/stores/canvas.ts
@@ -126,10 +126,10 @@ const refActions = {
     }
     this.db.set('ref', finalRef)
   },
-  async addRefMetadata(refId: string, { type, meta }: { type: string; meta: string }) {
+  async addRefMetadata(refId: string, { location, author }: { location: string; author: string }) {
     const ref = await this.db.get('ref', refId)
     if (!ref) return // TODO: ref might be missing id
-    this.db.set('ref', { ...ref, meta: { type, meta } })
+    this.db.set('ref', { ...ref, meta: { location, author } })
   },
   async removeRef(refId: string) {
     this.db.delete('ref', refId)

--- a/features/pocketbase/stores/refs.ts
+++ b/features/pocketbase/stores/refs.ts
@@ -14,7 +14,7 @@ export const useRefStore = create<{
   updateOne: (id: string, fields: Partial<StagedRef>) => Promise<RecordModel>
   addMetaData: (
     id: string,
-    { cat, meta }: { cat: string; meta: string }
+    { location, author }: { location?: string; author?: string }
   ) => Promise<RecordModel | void>
 }>((set) => ({
   refs: [],
@@ -30,10 +30,10 @@ export const useRefStore = create<{
   },
   // Reference an existing Ref, and create an ref off it
   reference: () => {},
-  addMetaData: async (id: string, { cat, meta }: { cat: string; meta: string }) => {
+  addMetaData: async (id: string, { location, author }: { location?: string; author?: string }) => {
     try {
-      const updatedRecord = await pocketbase.collection('refs').update(id, { type: cat, meta })
-      await canvasApp.actions.addRefMetadata(id, { type: cat, meta })
+      const updatedRecord = await pocketbase.collection('refs').update(id, { location, author })
+      await canvasApp.actions.addRefMetadata(id, { location: location ?? '', author: author ?? '' })
       return updatedRecord
     } catch (error) {
       console.error(error)

--- a/features/pocketbase/stores/refs.ts
+++ b/features/pocketbase/stores/refs.ts
@@ -30,9 +30,11 @@ export const useRefStore = create<{
   },
   // Reference an existing Ref, and create an ref off it
   reference: () => {},
-  addMetaData: async (id: string, meta: { meta: { location?: string; author?: string } }) => {
+  addMetaData: async (id: string, meta: { location?: string; author?: string }) => {
     try {
-      const updatedRecord = await pocketbase.collection('refs').update(id, { meta })
+      const updatedRecord = await pocketbase
+        .collection('refs')
+        .update(id, { meta: JSON.stringify(meta) })
       await canvasApp.actions.addRefMetadata(id, { meta })
       return updatedRecord
     } catch (error) {

--- a/features/pocketbase/stores/refs.ts
+++ b/features/pocketbase/stores/refs.ts
@@ -30,10 +30,10 @@ export const useRefStore = create<{
   },
   // Reference an existing Ref, and create an ref off it
   reference: () => {},
-  addMetaData: async (id: string, { location, author }: { location?: string; author?: string }) => {
+  addMetaData: async (id: string, meta: { meta: { location?: string; author?: string } }) => {
     try {
-      const updatedRecord = await pocketbase.collection('refs').update(id, { location, author })
-      await canvasApp.actions.addRefMetadata(id, { location: location ?? '', author: author ?? '' })
+      const updatedRecord = await pocketbase.collection('refs').update(id, { meta })
+      await canvasApp.actions.addRefMetadata(id, { meta })
       return updatedRecord
     } catch (error) {
       console.error(error)

--- a/ui/actions/CategoriseRef.tsx
+++ b/ui/actions/CategoriseRef.tsx
@@ -36,9 +36,19 @@ export const CategoriseRef = ({
     if (!existingRef.id) return
 
     try {
-      const record = await addMetaData(existingRef.id, { cat: category, meta })
-      console.log('completed categorisation: ', record)
-      if (record) onComplete(record)
+      if (category === 'place') {
+        // meta is a location
+        const record = await addMetaData(existingRef.id, { location: meta })
+        console.log('completed categorisation: ', record)
+        if (record) onComplete(record)
+      } else if (category === 'artwork') {
+        // meta is an author
+        const record = await addMetaData(existingRef.id, { author: meta })
+        console.log('completed categorisation: ', record)
+        if (record) onComplete(record)
+      } else {
+        // meta is other
+      }
     } catch (error) {
       console.error(error)
       throw error
@@ -68,7 +78,7 @@ export const CategoriseRef = ({
               iconColor={c.accent}
               iconSize={s.$2}
               onPress={() => categorise('place')}
-              iconBefore={"Castle" as any}
+              iconBefore={'Castle' as any}
               iconBeforeCustom={true}
               title="Place"
             />
@@ -95,13 +105,12 @@ export const CategoriseRef = ({
         </YStack>
         <YStack gap={s.$08} style={{ justifyContent: 'center', width: '100%' }}>
           <View style={{ width: '100%', paddingHorizontal: s.$2 }}>
-            
             <Button
               variant="basicLeft"
               iconColor={c.accent}
               iconSize={s.$2}
               onPress={() => categorise('artwork')}
-              iconBefore={"Palette" as any}
+              iconBefore={'Palette' as any}
               iconBeforeCustom={true}
               title="Work of art"
             />
@@ -136,7 +145,7 @@ export const CategoriseRef = ({
                 categorise('other')
                 done()
               }}
-              iconBefore={"Infinity" as any}
+              iconBefore={'Infinity' as any}
               iconBeforeCustom={true}
               title="Other"
             />

--- a/ui/actions/CategoriseRef.tsx
+++ b/ui/actions/CategoriseRef.tsx
@@ -36,19 +36,14 @@ export const CategoriseRef = ({
     if (!existingRef.id) return
 
     try {
+      const metaField: { location?: string; author?: string } = {}
       if (category === 'place') {
-        // meta is a location
-        const record = await addMetaData(existingRef.id, { location: meta })
-        console.log('completed categorisation: ', record)
-        if (record) onComplete(record)
+        metaField.location = meta
       } else if (category === 'artwork') {
-        // meta is an author
-        const record = await addMetaData(existingRef.id, { author: meta })
-        console.log('completed categorisation: ', record)
-        if (record) onComplete(record)
-      } else {
-        // meta is other
+        metaField.author = meta
       }
+      const record = await addMetaData(existingRef.id, metaField)
+      if (record) onComplete(record)
     } catch (error) {
       console.error(error)
       throw error

--- a/ui/actions/RefForm.tsx
+++ b/ui/actions/RefForm.tsx
@@ -73,13 +73,13 @@ export const RefForm = ({
 
     console.log('image success')
     // Prefetch image to ensure it's in cache
-    // Image.prefetch(imageUrl)
-    // .then(() => {
-    setPinataSource(imageUrl)
-    // })
-    // .catch((err) => {
-    // console.error('Failed to prefetch image:', err)
-    // })
+    Image.prefetch(imageUrl)
+      .then(() => {
+        setPinataSource(imageUrl)
+      })
+      .catch((err) => {
+        console.error('Failed to prefetch image:', err)
+      })
   }
 
   const handleDataChange = (d: { title: string; url: string; image?: string | undefined }) => {

--- a/ui/actions/RefForm.tsx
+++ b/ui/actions/RefForm.tsx
@@ -71,14 +71,15 @@ export const RefForm = ({
   const handleImageSuccess = (imageUrl: string) => {
     setUploadInProgress(false)
 
+    console.log('image success')
     // Prefetch image to ensure it's in cache
-    Image.prefetch(imageUrl)
-      .then(() => {
-        setPinataSource(imageUrl)
-      })
-      .catch((err) => {
-        console.error('Failed to prefetch image:', err)
-      })
+    // Image.prefetch(imageUrl)
+    // .then(() => {
+    setPinataSource(imageUrl)
+    // })
+    // .catch((err) => {
+    // console.error('Failed to prefetch image:', err)
+    // })
   }
 
   const handleDataChange = (d: { title: string; url: string; image?: string | undefined }) => {
@@ -118,6 +119,7 @@ export const RefForm = ({
     }
   }
 
+  console.log(pinataSource, title, uploadInProgress, createInProgress)
   return (
     <View
       style={{ justifyContent: 'center', alignItems: 'center', gap: s.$2, marginVertical: s.$4 }}

--- a/ui/actions/RefForm.tsx
+++ b/ui/actions/RefForm.tsx
@@ -119,7 +119,6 @@ export const RefForm = ({
     }
   }
 
-  console.log(pinataSource, title, uploadInProgress, createInProgress)
   return (
     <View
       style={{ justifyContent: 'center', alignItems: 'center', gap: s.$2, marginVertical: s.$4 }}

--- a/ui/profiles/EditableItem.tsx
+++ b/ui/profiles/EditableItem.tsx
@@ -14,8 +14,55 @@ import { ListContainer } from '../lists/ListContainer'
 import Animated, { useAnimatedStyle } from 'react-native-reanimated'
 import { BottomSheetTextInput, BottomSheetView } from '@gorhom/bottom-sheet'
 import { KeyboardAvoidingView } from 'react-native-keyboard-controller'
+import { XStack, YStack } from '../core/Stacks'
+import { RefsRecord } from '@/features/pocketbase/stores/pocketbase-types'
 
 const win = Dimensions.get('window')
+
+const LocationMeta = ({ location }: { location: string }) => {
+  return (
+    <XStack style={{ alignItems: 'center' }} gap={s.$05}>
+      <Ionicons name="location-outline" size={s.$1} color={c.muted} />
+      <Heading tag="smallmuted">{location}</Heading>
+    </XStack>
+  )
+}
+
+const AuthorMeta = ({ author }: { author: string }) => {
+  return (
+    <XStack style={{ alignItems: 'center' }} gap={s.$05}>
+      <Ionicons name="person-outline" size={s.$1} color={c.muted} />
+      <Heading tag="smallmuted">{author}</Heading>
+    </XStack>
+  )
+}
+
+const Meta = ({ refRecord }: { refRecord: RefsRecord }) => {
+  if (!refRecord) return
+
+  let refMeta: { location?: string; author?: string } = {}
+  try {
+    refMeta = JSON.parse(refRecord.meta!)
+  } catch (e) {
+    // ignore parsing errors, this must mean the meta is just a string  value
+  }
+
+  let location = refMeta.location
+  let author = refMeta.author
+
+  if (refRecord.type === 'place') {
+    location = refRecord.meta
+  } else if (refRecord.type === 'artwork') {
+    author = refRecord.meta
+  }
+
+  return (
+    <YStack gap={s.$05} style={{ paddingVertical: s.$05 }}>
+      {location && <LocationMeta location={location} />}
+      {author && <AuthorMeta author={author} />}
+    </YStack>
+  )
+}
 
 const EditableItemComponent = ({
   item,
@@ -145,7 +192,7 @@ const EditableItemComponent = ({
                 }}
               >
                 <Heading tag="h2">{item.expand?.ref?.title}</Heading>
-                <Heading tag="smallmuted">{item.expand?.ref?.meta}</Heading>
+                {item.expand?.ref ? <Meta refRecord={item.expand?.ref} /> : null}
               </BottomSheetView>
             </Pressable>
 


### PR DESCRIPTION
Fixes #116

This PR updates the ref creation code to store the author and location in the `meta` column in a JSON blob, i.e. `{"author": "J. G. Ballard", "location": "A40 Bridge near White City"}`. For existing refs, we can infer whether the `meta` column is a location or author based on the `type` column. We also display this information in the details carousel:

![Screenshot 2025-05-20 at 9 50 04 PM](https://github.com/user-attachments/assets/d43ad6ee-7603-4d33-872b-5569b53ba3d1)
