### PR TITLE
120, 121, 125, 144

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -145,6 +145,7 @@ function RootLayoutNav() {
             presentation: 'transparentModal',
             headerShown: false,
             contentStyle: { backgroundColor: 'transparent' },
+            animation: 'fade'
           }}
         />
         <Stack.Screen

--- a/ui/actions/CategoriseRef.tsx
+++ b/ui/actions/CategoriseRef.tsx
@@ -58,7 +58,7 @@ export const CategoriseRef = ({
               {item.image && (
                 <SimplePinataImage
                   originalSource={item.image}
-                  imageOptions={{ width: s.$12 * 2, height: s.$12 * 2 }}
+                  imageOptions={{ width: s.$12, height: s.$12 }}
                   style={{
                     width: s.$12,
                     height: s.$12,

--- a/ui/atoms/Avatar.tsx
+++ b/ui/atoms/Avatar.tsx
@@ -17,7 +17,7 @@ export const Avatar = ({ source, size = s.$3 }: { source: string | undefined; si
         <SimplePinataImage
           style={{ width: '100%', height: '100%', borderRadius: size / 2, backgroundColor: '#ddd' }}
           originalSource={source}
-          imageOptions={{ width: size * 2, height: size * 2 }}
+          imageOptions={{ width: size, height: size }}
         />
       </View>
     </>

--- a/ui/atoms/PressableImage.tsx
+++ b/ui/atoms/PressableImage.tsx
@@ -5,14 +5,14 @@ import { SimplePinataImage } from '../images/SimplePinataImage'
 export default function PressableImage({ source, size }: { source: string; size: number }) {
   const [visible, setVisible] = useState(false)
 
-  const { width, height, scale } = useWindowDimensions()
+  const { width, height } = useWindowDimensions()
 
   return (
     <>
       <Pressable onPress={() => setVisible(true)}>
         <SimplePinataImage
           originalSource={source}
-          imageOptions={{ width: size * scale, height: size * scale }}
+          imageOptions={{ width: size, height: size }}
           style={{ width: size, height: size, backgroundColor: 'transparent' }}
         />
       </Pressable>
@@ -23,8 +23,8 @@ export default function PressableImage({ source, size }: { source: string; size:
             originalSource={source}
             style={{ width: width, height: width }}
             imageOptions={{
-              width: width * scale,
-              height: height * scale,
+              width: width,
+              height: height,
             }}
           />
         </Pressable>

--- a/ui/images/SimplePinataImage.tsx
+++ b/ui/images/SimplePinataImage.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useMemo } from 'react'
 import { Image, type ImageProps } from 'expo-image'
 import { constructPinataUrl, type OptimizeImageOptions } from '@/features/pinata'
 import { useImageStore } from '@/features/pocketbase/stores/images'
-import { View } from 'react-native'
+import { useWindowDimensions, View } from 'react-native'
 
 function useSignedImageUrl(originalSource: string, imageOptions: OptimizeImageOptions) {
   const [loading, setLoading] = useState(true)
@@ -40,7 +40,12 @@ export const SimplePinataImage = ({
   placeholderContentFit?: ImageProps['contentFit']
   imageOptions: OptimizeImageOptions
 } & Omit<ImageProps, 'source'>) => {
-  const { source, loading } = useSignedImageUrl(originalSource, imageOptions)
+  const scale =  useWindowDimensions().scale
+  const imageOptionsWithScale = {
+    height: imageOptions.height * scale,
+    width: imageOptions.width * scale,
+  }
+  const { source, loading } = useSignedImageUrl(originalSource, imageOptionsWithScale)
   // Always render an image - either the placeholder during loading or the final source
   return loading ? (
     <View />

--- a/ui/profiles/BacklogBottomSheet.tsx
+++ b/ui/profiles/BacklogBottomSheet.tsx
@@ -25,6 +25,7 @@ export default function BacklogBottomSheet({
 
   const ownProfile = profile.id === user?.id
   const isMinimised = ownProfile && index === 0
+  const HANDLE_HEIGHT = s.$2
 
   const renderBackdrop = useCallback(
     (p: any) => (
@@ -45,7 +46,7 @@ export default function BacklogBottomSheet({
           alignItems: 'center',
           justifyContent: 'center',
           display: isMinimised ? 'none' : 'flex',
-          height: s.$3,
+          height: HANDLE_HEIGHT,
         }}
       >
         <Animated.View
@@ -73,7 +74,12 @@ export default function BacklogBottomSheet({
         onPress={() => {
           if (backlogSheetRef.current && isMinimised) backlogSheetRef.current.snapToIndex(1)
         }}
-        style={{ paddingTop: isMinimised ? s.$3 : 0, paddingBottom: isMinimised ? s.$6 : s.$1 }}
+        style={{
+          // handle is hidden while minimised, so this is needed to make sure 
+          // the "My backlog" heading doesn't shift around when opening/closing the sheet
+          paddingTop: isMinimised ? HANDLE_HEIGHT : 0, 
+          paddingBottom: isMinimised ? s.$6 : s.$1,
+        }}
       >
         {ownProfile ? (
           <XStack

--- a/ui/profiles/BacklogList.tsx
+++ b/ui/profiles/BacklogList.tsx
@@ -118,22 +118,21 @@ export default function BacklogList({ items }: { items: ExpandedItem[] }) {
                       gap={s.$1}
                       style={{
                         paddingVertical: s.$05,
-                        paddingHorizontal: s.$1,
                         alignItems: 'center',
                       }}
                     >
                       <SimplePinataImage
                         originalSource={i.image}
-                        imageOptions={{ width: s.$2, height: s.$2 }}
+                        imageOptions={{ width: s.$4, height: s.$4 }}
                         style={{
-                          width: s.$2,
-                          height: s.$2,
+                          width: s.$4,
+                          height: s.$4,
                           borderRadius: s.$075,
                           backgroundColor: c.olive2,
                         }}
                       />
                       <Text
-                        style={{ color: c.white, fontSize: s.$1, width: '80%' }}
+                        style={{ color: c.white, fontSize: s.$1, flex: 1 }}
                         numberOfLines={2}
                       >
                         {i.expand?.ref?.title?.trim()}


### PR DESCRIPTION
Fixes #120 #121 #125 #144

(121) In order for images not to be blurry, we have to take pixel density into account when setting width/height. This should be handled inside SimplePinataImage so we don't have to think about it every time we add an image somewhere.

