### PR TITLE
Bug fix: content should not move up when ref is clicked

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -145,7 +145,7 @@ function RootLayoutNav() {
             presentation: 'transparentModal',
             headerShown: false,
             contentStyle: { backgroundColor: 'transparent' },
-            animation: 'fade'
+            animation: 'fade',
           }}
         />
         <Stack.Screen
@@ -190,7 +190,10 @@ function RootLayoutNav() {
           name="user/[userName]/modal"
           options={{
             title: 'Details',
-            animation: 'none',
+            presentation: 'transparentModal',
+            headerShown: false,
+            contentStyle: { backgroundColor: 'transparent' },
+            animation: 'fade',
           }}
         />
       </Stack>

--- a/ui/navigation/Navigation.tsx
+++ b/ui/navigation/Navigation.tsx
@@ -1,4 +1,4 @@
-import { Link, usePathname, useGlobalSearchParams, router } from 'expo-router'
+import { Link, useGlobalSearchParams, router } from 'expo-router'
 import { Text, View, Pressable } from 'react-native'
 import { Avatar } from '../atoms/Avatar'
 import { c, s } from '@/features/style'
@@ -12,7 +12,6 @@ import MessageIcon from '@/assets/icons/message.svg'
 export const Navigation = () => {
   const { user } = useUserStore()
 
-  const pathName = usePathname()
   const { addingTo, removingId } = useGlobalSearchParams()
 
   const { saves, messagesPerConversation, conversations, memberships } = useMessageStore()
@@ -46,7 +45,7 @@ export const Navigation = () => {
     [messagesPerConversation, memberships, user]
   )
 
-  if (!user || /\/user\/.*\/modal/.test(pathName)) return null
+  if (!user) return null
 
   return (
     <View


### PR DESCRIPTION
Fixes #127 and #119

Used the same technique that we used with the saves modal, also the shadow covers the navigation bar

https://github.com/user-attachments/assets/16e857d4-8c20-4c47-b3cc-8a6b2b064013

