### PR TITLE
remove duplicate function

### DIFF
--- a/features/pocketbase/stores/items.ts
+++ b/features/pocketbase/stores/items.ts
@@ -119,19 +119,6 @@ export const useItemStore = create<{
       throw e
     }
   },
-  removeFromList: async (id: string, ref: CompleteRef) => {
-    try {
-      const record = await pocketbase
-        .collection('items')
-        .update(id, { 'children-': ref.id, expand: 'children' })
-      await canvasApp.actions.removeItemFromList(id, ref)
-
-      return record
-    } catch (error) {
-      console.error(error)
-      throw error
-    }
-  },
   moveToBacklog: async (id: string) => {
     try {
       const record = await pocketbase.collection<ItemsRecord>('items').update(id, { backlog: true })


### PR DESCRIPTION
Move to backlog didn't work because the items store had two functions called "removeFromList", so I deleted one of them... 
Fixes #129 