### PR TITLE
Fix 174: navigation bar not working with backdrop effect

### DIFF
--- a/features/style/backdrop.ts
+++ b/features/style/backdrop.ts
@@ -1,0 +1,24 @@
+import { makeMutable, SharedValue } from 'react-native-reanimated'
+import { create } from 'zustand'
+
+type BackdropState = {
+  animatedIndex?: SharedValue<number>
+  maxOpacity: number
+  setMaxOpacity: (opacity: number) => void
+  disappearsOnIndex: number
+  setDisappearsOnIndex: (index: number) => void
+  appearsOnIndex: number
+  setAppearsOnIndex: (index: number) => void
+}
+
+const animatedIndex = makeMutable(0)
+
+export const useBackdropStore = create<BackdropState>((set) => ({
+  animatedIndex,
+  maxOpacity: 0.5,
+  setMaxOpacity: (opacity: number) => set({ maxOpacity: opacity }),
+  disappearsOnIndex: 0,
+  setDisappearsOnIndex: (index: number) => set({ disappearsOnIndex: index }),
+  appearsOnIndex: 1,
+  setAppearsOnIndex: (index: number) => set({ appearsOnIndex: index }),
+}))

--- a/features/style/backdrop.ts
+++ b/features/style/backdrop.ts
@@ -3,6 +3,8 @@ import { create } from 'zustand'
 
 type BackdropState = {
   animatedIndex?: SharedValue<number>
+  doPress: () => void
+  setDoPress: (doPress: () => void) => void
   maxOpacity: number
   setMaxOpacity: (opacity: number) => void
   disappearsOnIndex: number
@@ -15,6 +17,8 @@ const animatedIndex = makeMutable(0)
 
 export const useBackdropStore = create<BackdropState>((set) => ({
   animatedIndex,
+  doPress: () => {},
+  setDoPress: (doPress: () => void) => set({ doPress }),
   maxOpacity: 0.5,
   setMaxOpacity: (opacity: number) => set({ maxOpacity: opacity }),
   disappearsOnIndex: 0,

--- a/hooks/useBackdropStyle.ts
+++ b/hooks/useBackdropStyle.ts
@@ -1,0 +1,21 @@
+import { useBackdropStore } from '@/features/style/backdrop'
+import { Extrapolation, interpolate, useAnimatedStyle } from 'react-native-reanimated'
+
+export const useBackdropStyle = () => {
+  const { animatedIndex, disappearsOnIndex, appearsOnIndex, maxOpacity } = useBackdropStore()
+
+  const containerAnimatedStyle = useAnimatedStyle(() => {
+    const opacityValue = interpolate(
+      animatedIndex!.value || 0,
+      [-1, disappearsOnIndex, appearsOnIndex],
+      [0, 0, maxOpacity],
+      Extrapolation.CLAMP
+    )
+
+    return {
+      opacity: opacityValue,
+      display: opacityValue === 0 ? 'none' : 'flex',
+    }
+  }, [animatedIndex, disappearsOnIndex, appearsOnIndex, maxOpacity])
+  return containerAnimatedStyle
+}

--- a/ui/actions/SearchBottomSheet.tsx
+++ b/ui/actions/SearchBottomSheet.tsx
@@ -38,7 +38,7 @@ export default function SearchBottomSheet() {
 
   const { user } = useUserStore()
 
-  const { animatedIndex, setAppearsOnIndex, setDisappearsOnIndex, setMaxOpacity } =
+  const { animatedIndex, setAppearsOnIndex, setDisappearsOnIndex, setMaxOpacity, setDoPress } =
     useBackdropStore()
 
   const navigation = useNavigation()
@@ -49,6 +49,11 @@ export default function SearchBottomSheet() {
       setAppearsOnIndex(1)
       setDisappearsOnIndex(0)
       setMaxOpacity(0.5)
+      setDoPress(() => {
+        if (searchSheetRef.current) {
+          searchSheetRef.current.collapse()
+        }
+      })
     }
   }, [focused])
 

--- a/ui/actions/SearchBottomSheet.tsx
+++ b/ui/actions/SearchBottomSheet.tsx
@@ -5,7 +5,7 @@ import BottomSheet, {
   BottomSheetTextInput,
   BottomSheetView,
 } from '@gorhom/bottom-sheet'
-import { useCallback, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Pressable, Text } from 'react-native'
 import { Heading } from '../typo/Heading'
 import { XStack, YStack } from '../core/Stacks'
@@ -14,9 +14,10 @@ import { CompleteRef, Item, Profile } from '@/features/pocketbase/stores/types'
 import { pocketbase, useUserStore } from '@/features/pocketbase'
 import { SimplePinataImage } from '../images/SimplePinataImage'
 import { Ionicons } from '@expo/vector-icons'
-import { router } from 'expo-router'
+import { router, useNavigation } from 'expo-router'
 import { Sheet } from '../core/Sheets'
 import { NewRef, NewRefStep } from './NewRef'
+import { useBackdropStore } from '@/features/style/backdrop'
 
 const HEADER_HEIGHT = s.$8
 
@@ -36,6 +37,21 @@ export default function SearchBottomSheet() {
   const [refs, setRefs] = useState<CompleteRef[]>([])
 
   const { user } = useUserStore()
+
+  const { animatedIndex, setAppearsOnIndex, setDisappearsOnIndex, setMaxOpacity } =
+    useBackdropStore()
+
+  const navigation = useNavigation()
+  const focused = navigation.isFocused()
+
+  useEffect(() => {
+    if (focused) {
+      console.log(`updating: ${1} ${0} ${0.5}`)
+      setAppearsOnIndex(1)
+      setDisappearsOnIndex(0)
+      setMaxOpacity(0.5)
+    }
+  }, [focused])
 
   // search console should expand when new refs are added to the search
   // but it shouldn't be taller than ~4 refs in its minimised form
@@ -86,18 +102,6 @@ export default function SearchBottomSheet() {
     router.push(`/search?refs=${refs.map((r) => r.id).join(',')}`)
   }
 
-  const renderBackdrop = useCallback(
-    (p: any) => (
-      <BottomSheetBackdrop
-        {...p}
-        disappearsOnIndex={0}
-        appearsOnIndex={1}
-        pressBehavior={'collapse'}
-      />
-    ),
-    []
-  )
-
   return (
     <>
       <BottomSheet
@@ -106,6 +110,7 @@ export default function SearchBottomSheet() {
         enablePanDownToClose={false}
         snapPoints={[minSnapPoint, '50%']}
         index={0}
+        animatedIndex={animatedIndex}
         onChange={(i: number) => {
           setIndex(i)
           if (i === 0) {
@@ -114,7 +119,16 @@ export default function SearchBottomSheet() {
           }
         }}
         backgroundStyle={{ backgroundColor: c.olive, borderRadius: s.$4, paddingTop: 0 }}
-        backdropComponent={renderBackdrop}
+        backdropComponent={(p) => {
+          return (
+            <BottomSheetBackdrop
+              {...p}
+              disappearsOnIndex={0}
+              appearsOnIndex={1}
+              pressBehavior={'collapse'}
+            />
+          )
+        }}
         handleComponent={null}
         keyboardBehavior="interactive"
       >

--- a/ui/actions/SearchBottomSheet.tsx
+++ b/ui/actions/SearchBottomSheet.tsx
@@ -46,7 +46,6 @@ export default function SearchBottomSheet() {
 
   useEffect(() => {
     if (focused) {
-      console.log(`updating: ${1} ${0} ${0.5}`)
       setAppearsOnIndex(1)
       setDisappearsOnIndex(0)
       setMaxOpacity(0.5)

--- a/ui/core/Sheets.tsx
+++ b/ui/core/Sheets.tsx
@@ -43,7 +43,7 @@ export const Sheet = (props: any = { full: false, noNotch: false, noPadding: fal
       {...props}
     >
       <BottomSheetScrollView
-        keyboardShouldPersistTaps={props.keyboardShouldPersistTaps || "handled"}
+        keyboardShouldPersistTaps={props.keyboardShouldPersistTaps || 'handled'}
         showsVerticalScrollIndicator={false}
       >
         {props?.children}

--- a/ui/navigation/Navigation.tsx
+++ b/ui/navigation/Navigation.tsx
@@ -4,6 +4,7 @@ import { Avatar } from '../atoms/Avatar'
 import { c, s } from '@/features/style'
 import { useUserStore } from '@/features/pocketbase/stores/users'
 import { useMessageStore } from '@/features/pocketbase/stores/messages'
+import { NavigationBackdrop } from '@/ui/navigation/NavigationBackdrop'
 import { Badge } from '../atoms/Badge'
 import { useMemo } from 'react'
 import SavesIcon from '@/assets/icons/saves.svg'
@@ -48,57 +49,66 @@ export const Navigation = () => {
   if (!user) return null
 
   return (
-    <View
-      style={{
-        display: 'flex',
-        flexDirection: 'row',
-        marginTop: s.$6,
-        paddingHorizontal: s.$1,
-        alignItems: 'center',
-        paddingBottom: s.$05,
-      }}
-    >
-      <View>
-        <Link href={`/user/${user.userName}`}>
-          <Avatar source={user.image} size={42} />
-        </Link>
-      </View>
-      <View style={{ margin: 'auto' }}>
-        <Link dismissTo href="/">
-          <Text style={{ fontSize: 24, fontWeight: 'bold' }}>Refs</Text>
-        </Link>
-      </View>
-      <View style={{ top: -2, left: -10 }}>
-        <Pressable onPress={() => router.push('/saves/modal')}>
-          <SavesIcon />
-          <View
-            style={{
-              position: 'absolute',
-              height: '85%',
-              width: '100%',
-              justifyContent: 'center',
-              alignItems: 'center',
+    <View style={{ display: 'flex', flexDirection: 'row' }}>
+      <NavigationBackdrop />
+      <View
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          marginTop: s.$6,
+          width: '100%',
+          paddingHorizontal: s.$1,
+          alignItems: 'center',
+          paddingBottom: s.$05,
+        }}
+      >
+        <View>
+          <Link href={`/user/${user.userName}`}>
+            <Avatar source={user.image} size={42} />
+          </Link>
+        </View>
+        <View style={{ margin: 'auto' }}>
+          <Link dismissTo href="/">
+            <Text style={{ fontSize: 24, fontWeight: 'bold' }}>Refs</Text>
+          </Link>
+        </View>
+        <View style={{ top: -2, left: -10 }}>
+          <Pressable
+            onPress={() => {
+              console.log('pressing saves')
+              router.push('/saves/modal')
             }}
           >
-            {saves.length > 0 && (
-              <Text
-                style={{
-                  color: c.white,
-                  fontWeight: 'bold',
-                  fontSize: s.$08,
-                }}
-              >
-                {saves.length}
-              </Text>
-            )}
-          </View>
-        </Pressable>
-      </View>
-      <View style={{ top: -2 }}>
-        <Pressable onPress={() => router.push('/messages')}>
-          <MessageIcon />
-          {newMessages > 0 && <Badge count={newMessages} color={c.red} />}
-        </Pressable>
+            <SavesIcon />
+            <View
+              style={{
+                position: 'absolute',
+                height: '85%',
+                width: '100%',
+                justifyContent: 'center',
+                alignItems: 'center',
+              }}
+            >
+              {saves.length > 0 && (
+                <Text
+                  style={{
+                    color: c.white,
+                    fontWeight: 'bold',
+                    fontSize: s.$08,
+                  }}
+                >
+                  {saves.length}
+                </Text>
+              )}
+            </View>
+          </Pressable>
+        </View>
+        <View style={{ top: -2 }}>
+          <Pressable onPress={() => router.push('/messages')}>
+            <MessageIcon />
+            {newMessages > 0 && <Badge count={newMessages} color={c.red} />}
+          </Pressable>
+        </View>
       </View>
     </View>
   )

--- a/ui/navigation/NavigationBackdrop.tsx
+++ b/ui/navigation/NavigationBackdrop.tsx
@@ -1,0 +1,21 @@
+import Animated from 'react-native-reanimated'
+import { useBackdropStyle } from '@/hooks/useBackdropStyle'
+
+export const NavigationBackdrop = () => {
+  const containerAnimatedStyle = useBackdropStyle()
+
+  return (
+    <Animated.View
+      style={[
+        {
+          zIndex: 1000,
+          position: 'absolute',
+          height: '100%',
+          width: '100%',
+          backgroundColor: 'black',
+        },
+        containerAnimatedStyle,
+      ]}
+    />
+  )
+}

--- a/ui/navigation/NavigationBackdrop.tsx
+++ b/ui/navigation/NavigationBackdrop.tsx
@@ -1,11 +1,17 @@
 import Animated from 'react-native-reanimated'
 import { useBackdropStyle } from '@/hooks/useBackdropStyle'
+import { useBackdropStore } from '@/features/style/backdrop'
+import { Pressable } from 'react-native'
+
+const AnimatedPressable = Animated.createAnimatedComponent(Pressable)
 
 export const NavigationBackdrop = () => {
   const containerAnimatedStyle = useBackdropStyle()
+  const { doPress } = useBackdropStore()
 
   return (
-    <Animated.View
+    <AnimatedPressable
+      onPress={doPress}
       style={[
         {
           zIndex: 1000,

--- a/ui/profiles/BacklogBottomSheet.tsx
+++ b/ui/profiles/BacklogBottomSheet.tsx
@@ -1,6 +1,6 @@
 import { c, s } from '@/features/style'
 import BottomSheet, { BottomSheetBackdrop } from '@gorhom/bottom-sheet'
-import { RefObject, useCallback, useEffect, useState } from 'react'
+import { RefObject, useCallback, useEffect, useRef, useState } from 'react'
 import { Pressable, View } from 'react-native'
 import { Heading } from '../typo/Heading'
 import { XStack } from '../core/Stacks'
@@ -27,7 +27,7 @@ export default function BacklogBottomSheet({
   const navigation = useNavigation()
   const focused = navigation.isFocused()
 
-  const { animatedIndex, setAppearsOnIndex, setDisappearsOnIndex, setMaxOpacity } =
+  const { animatedIndex, setAppearsOnIndex, setDisappearsOnIndex, setMaxOpacity, setDoPress } =
     useBackdropStore()
 
   const ownProfile = profile.id === user?.id
@@ -43,6 +43,15 @@ export default function BacklogBottomSheet({
       setAppearsOnIndex(appearsOnIndex)
       setDisappearsOnIndex(disappearsOnIndex)
       setMaxOpacity(maxOpacity)
+      setDoPress(() => {
+        if (backlogSheetRef.current) {
+          if (ownProfile) {
+            backlogSheetRef.current.collapse()
+          } else {
+            backlogSheetRef.current.close()
+          }
+        }
+      })
     }
   }, [focused, appearsOnIndex, disappearsOnIndex, maxOpacity])
 

--- a/ui/profiles/BacklogBottomSheet.tsx
+++ b/ui/profiles/BacklogBottomSheet.tsx
@@ -1,6 +1,6 @@
 import { c, s } from '@/features/style'
 import BottomSheet, { BottomSheetBackdrop } from '@gorhom/bottom-sheet'
-import { RefObject, useCallback, useState } from 'react'
+import { RefObject, useCallback, useEffect, useState } from 'react'
 import { Pressable, View } from 'react-native'
 import { Heading } from '../typo/Heading'
 import { XStack } from '../core/Stacks'
@@ -8,6 +8,8 @@ import { Ionicons } from '@expo/vector-icons'
 import Animated, { FadeIn, FadeOut } from 'react-native-reanimated'
 import { Profile } from '@/features/pocketbase/stores/types'
 import { useUserStore } from '@/features/pocketbase'
+import { useBackdropStore } from '@/features/style/backdrop'
+import { useNavigation } from 'expo-router'
 
 export default function BacklogBottomSheet({
   children,
@@ -22,17 +24,34 @@ export default function BacklogBottomSheet({
 }) {
   const [index, setIndex] = useState(0)
   const { user } = useUserStore()
+  const navigation = useNavigation()
+  const focused = navigation.isFocused()
+
+  const { animatedIndex, setAppearsOnIndex, setDisappearsOnIndex, setMaxOpacity } =
+    useBackdropStore()
 
   const ownProfile = profile.id === user?.id
   const isMinimised = ownProfile && index === 0
   const HANDLE_HEIGHT = s.$2
 
+  const disappearsOnIndex = ownProfile ? 0 : -1
+  const appearsOnIndex = ownProfile ? 1 : 0
+  const maxOpacity = 0.5
+
+  useEffect(() => {
+    if (focused) {
+      setAppearsOnIndex(appearsOnIndex)
+      setDisappearsOnIndex(disappearsOnIndex)
+      setMaxOpacity(maxOpacity)
+    }
+  }, [focused, appearsOnIndex, disappearsOnIndex, maxOpacity])
+
   const renderBackdrop = useCallback(
     (p: any) => (
       <BottomSheetBackdrop
         {...p}
-        disappearsOnIndex={ownProfile ? 0 : -1}
-        appearsOnIndex={ownProfile ? 1 : 0}
+        disappearsOnIndex={disappearsOnIndex}
+        appearsOnIndex={appearsOnIndex}
         pressBehavior={ownProfile ? 'collapse' : 'close'}
       />
     ),
@@ -60,6 +79,7 @@ export default function BacklogBottomSheet({
 
   return (
     <BottomSheet
+      animatedIndex={animatedIndex}
       enableDynamicSizing={false}
       ref={backlogSheetRef}
       index={ownProfile ? 0 : -1}
@@ -75,9 +95,9 @@ export default function BacklogBottomSheet({
           if (backlogSheetRef.current && isMinimised) backlogSheetRef.current.snapToIndex(1)
         }}
         style={{
-          // handle is hidden while minimised, so this is needed to make sure 
+          // handle is hidden while minimised, so this is needed to make sure
           // the "My backlog" heading doesn't shift around when opening/closing the sheet
-          paddingTop: isMinimised ? HANDLE_HEIGHT : 0, 
+          paddingTop: isMinimised ? HANDLE_HEIGHT : 0,
           paddingBottom: isMinimised ? s.$6 : s.$1,
         }}
       >

--- a/ui/profiles/Profile.tsx
+++ b/ui/profiles/Profile.tsx
@@ -72,7 +72,6 @@ export const Profile = ({ userName }: { userName: string }) => {
       setProfile(profile)
 
       const gridItems = await getProfileItems(userName)
-      console.log(JSON.stringify(gridItems))
       setGridItems(gridItems)
 
       const backlogItems = await getBacklogItems(userName)


### PR DESCRIPTION
This PR fixes the situation where some of the bottom sheet elements have a backdrop, but the backdrop is not being applied to the Navigation bar. A nice thing about this is that we finally have a way to put a backdrop effect on the navigation bar *without* having to make a new route.

The solution here was to create a shared state variable using React Reanimated which records the current `animatedIndex` variable of the currently displayed bottom sheet. NOTE: this only works if there is only one bottom sheet that has a backdrop on the screen at once.