### PR TITLE
only hide splash screen when we know whether the user is logged in

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -15,7 +15,7 @@ import NetInfo from '@react-native-community/netinfo'
 import { SafeAreaProvider } from 'react-native-safe-area-context'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import { useEffect } from 'react'
-import { StatusBar, useColorScheme, useWindowDimensions, View } from 'react-native'
+import { StatusBar, useColorScheme } from 'react-native'
 import { Navigation } from '@/ui/navigation/Navigation'
 import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native'
 import { useFonts } from 'expo-font'
@@ -73,12 +73,7 @@ function FontProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     SystemUI.setBackgroundColorAsync(c.surface)
-
-    if (interLoaded || interError) {
-      // Hide the splash screen after the fonts have loaded (or an error was returned) and the UI is ready.
-      SplashScreen.hideAsync()
-    }
-  }, [interLoaded, interError])
+  }, [])
 
   if (!interLoaded && !interError) {
     return null

--- a/features/home/screen.tsx
+++ b/features/home/screen.tsx
@@ -1,7 +1,7 @@
 import { View, Dimensions, DimensionValue } from 'react-native'
 import { useEffect } from 'react'
 import { Button, YStack, Heading } from '../../ui/index'
-import { pocketbase, useUserStore } from '@/features/pocketbase'
+import { useUserStore } from '@/features/pocketbase'
 import Animated, {
   useAnimatedStyle,
   Easing,
@@ -10,9 +10,8 @@ import Animated, {
   useSharedValue,
 } from 'react-native-reanimated'
 
-import { router } from 'expo-router'
+import { router, SplashScreen } from 'expo-router'
 import { c, s } from '@/features/style/index'
-import { UserProfileScreen } from '../user/profile-screen'
 import { Feed } from './feed'
 
 const dims = Dimensions.get('window')
@@ -62,12 +61,14 @@ function RotatingImage() {
 }
 
 export function HomeScreen() {
-  const { user } = useUserStore()
+  const { user, userLoaded } = useUserStore()
 
   useEffect(() => {
-    console.log('USER ON HOMESCREEN', user?.userName)
-    console.log('Pocketbase auth store', pocketbase.authStore.isValid)
-  }, [user, pocketbase])
+    // we should only hide the splash screen when we know whether the user is logged in or not
+    if (userLoaded) {
+      SplashScreen.hideAsync()
+    }
+  }, [userLoaded])
 
   if (user) {
     // if the user is logged in, show the user's profile

--- a/features/pocketbase/stores/users.ts
+++ b/features/pocketbase/stores/users.ts
@@ -4,6 +4,7 @@ import { Profile, EmptyProfile, ExpandedProfile, Item } from './types'
 import { UsersRecord, UsersResponse, ItemsResponse } from './pocketbase-types'
 import { canvasApp } from './canvas'
 import { ClientResponseError } from 'pocketbase'
+import { SplashScreen } from 'expo-router'
 
 export const isProfile = (profile: Profile | EmptyProfile | null): profile is Profile => {
   return profile !== null && Object.keys(profile).length > 0
@@ -12,6 +13,7 @@ export const isProfile = (profile: Profile | EmptyProfile | null): profile is Pr
 export const useUserStore = create<{
   stagedUser: Partial<Profile>
   user: Profile | null
+  userLoaded: boolean
   register: () => Promise<ExpandedProfile>
   updateUser: (fields: Partial<Profile>) => Promise<Profile>
   updateStagedUser: (formFields: Partial<Profile>) => void
@@ -26,6 +28,7 @@ export const useUserStore = create<{
   stagedUser: {},
   user: null, // user is ALWAYS the user of the app, this is only set if the user is logged in
   users: [],
+  userLoaded: false,
   //
   //
   //
@@ -39,11 +42,13 @@ export const useUserStore = create<{
 
         set(() => ({
           user: record,
+          userLoaded: true,
         }))
       } catch (error) {
         console.error('Failed to sync user state:', error)
         // If we can't get the user record, clear the auth store
         pocketbase.authStore.clear()
+        set(() => ({ userLoaded: true }))
       }
     }
   },


### PR DESCRIPTION
Fixes: https://github.com/refs-nyc/refs/issues/93

We have a bug right now where when you start the app, it has to retrieve your pocketbase authenticated user, during which time the login view flickers on the screen. This PR fixes the startup code so that it doesn't do this.