### PR TITLE
Revert "only hide splash screen when we know whether the user is logged in"

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -15,7 +15,7 @@ import NetInfo from '@react-native-community/netinfo'
 import { SafeAreaProvider } from 'react-native-safe-area-context'
 import { GestureHandlerRootView } from 'react-native-gesture-handler'
 import { useEffect } from 'react'
-import { StatusBar, useColorScheme } from 'react-native'
+import { StatusBar, useColorScheme, useWindowDimensions, View } from 'react-native'
 import { Navigation } from '@/ui/navigation/Navigation'
 import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native'
 import { useFonts } from 'expo-font'
@@ -73,7 +73,12 @@ function FontProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     SystemUI.setBackgroundColorAsync(c.surface)
-  }, [])
+
+    if (interLoaded || interError) {
+      // Hide the splash screen after the fonts have loaded (or an error was returned) and the UI is ready.
+      SplashScreen.hideAsync()
+    }
+  }, [interLoaded, interError])
 
   if (!interLoaded && !interError) {
     return null

--- a/features/home/screen.tsx
+++ b/features/home/screen.tsx
@@ -1,7 +1,7 @@
 import { View, Dimensions, DimensionValue } from 'react-native'
 import { useEffect } from 'react'
 import { Button, YStack, Heading } from '../../ui/index'
-import { useUserStore } from '@/features/pocketbase'
+import { pocketbase, useUserStore } from '@/features/pocketbase'
 import Animated, {
   useAnimatedStyle,
   Easing,
@@ -10,8 +10,9 @@ import Animated, {
   useSharedValue,
 } from 'react-native-reanimated'
 
-import { router, SplashScreen } from 'expo-router'
+import { router } from 'expo-router'
 import { c, s } from '@/features/style/index'
+import { UserProfileScreen } from '../user/profile-screen'
 import { Feed } from './feed'
 
 const dims = Dimensions.get('window')
@@ -61,14 +62,12 @@ function RotatingImage() {
 }
 
 export function HomeScreen() {
-  const { user, userLoaded } = useUserStore()
+  const { user } = useUserStore()
 
   useEffect(() => {
-    // we should only hide the splash screen when we know whether the user is logged in or not
-    if (userLoaded) {
-      SplashScreen.hideAsync()
-    }
-  }, [userLoaded])
+    console.log('USER ON HOMESCREEN', user?.userName)
+    console.log('Pocketbase auth store', pocketbase.authStore.isValid)
+  }, [user, pocketbase])
 
   if (user) {
     // if the user is logged in, show the user's profile

--- a/features/pocketbase/stores/users.ts
+++ b/features/pocketbase/stores/users.ts
@@ -4,7 +4,6 @@ import { Profile, EmptyProfile, ExpandedProfile, Item } from './types'
 import { UsersRecord, UsersResponse, ItemsResponse } from './pocketbase-types'
 import { canvasApp } from './canvas'
 import { ClientResponseError } from 'pocketbase'
-import { SplashScreen } from 'expo-router'
 
 export const isProfile = (profile: Profile | EmptyProfile | null): profile is Profile => {
   return profile !== null && Object.keys(profile).length > 0
@@ -13,7 +12,6 @@ export const isProfile = (profile: Profile | EmptyProfile | null): profile is Pr
 export const useUserStore = create<{
   stagedUser: Partial<Profile>
   user: Profile | null
-  userLoaded: boolean
   register: () => Promise<ExpandedProfile>
   updateUser: (fields: Partial<Profile>) => Promise<Profile>
   updateStagedUser: (formFields: Partial<Profile>) => void
@@ -28,7 +26,6 @@ export const useUserStore = create<{
   stagedUser: {},
   user: null, // user is ALWAYS the user of the app, this is only set if the user is logged in
   users: [],
-  userLoaded: false,
   //
   //
   //
@@ -42,13 +39,11 @@ export const useUserStore = create<{
 
         set(() => ({
           user: record,
-          userLoaded: true,
         }))
       } catch (error) {
         console.error('Failed to sync user state:', error)
         // If we can't get the user record, clear the auth store
         pocketbase.authStore.clear()
-        set(() => ({ userLoaded: true }))
       }
     }
   },


### PR DESCRIPTION
Reverts refs-nyc/refs#191

Doesn't work when logged out - we need to do this again and properly test it for both when the user is logged out and when the user is logged in.