### PR TITLE
Display edit item form when adding ref from other users profile

### DIFF
--- a/features/pocketbase/index.tsx
+++ b/features/pocketbase/index.tsx
@@ -6,7 +6,7 @@ import { StagedRef, CompleteRef, Item, ExpandedItem } from './stores/types'
 
 const addToProfile: (
   stagedRef: StagedRef | CompleteRef,
-  options: { text?: string; backlog?: boolean; list?: boolean }
+  options: { image?: string; text?: string; backlog?: boolean; list?: boolean }
 ) => Promise<ExpandedItem> = async (stagedRef, options = {}) => {
   console.log('WE GOT STAGED', 'list' in stagedRef ? stagedRef.list : null)
   console.log('WE GOT OPTIONS', options.list)
@@ -21,7 +21,7 @@ const addToProfile: (
     const existingRef = stagedRef
     newItem = await itemStore.push({
       ref: existingRef.id,
-      image: existingRef?.image,
+      image: options.image || existingRef?.image,
       creator: pocketbase.authStore?.record?.id,
       text: options.text,
       backlog: !!options.backlog,
@@ -31,7 +31,7 @@ const addToProfile: (
     const newRef = await refStore.push({ ...stagedRef, creator: pocketbase.authStore?.record?.id })
     newItem = await itemStore.push({
       ref: newRef.id,
-      image: newRef.image,
+      image: options.image || newRef.image,
       creator: pocketbase.authStore?.record?.id || '',
       text: options.text,
       backlog: !!options.backlog,

--- a/features/pocketbase/index.tsx
+++ b/features/pocketbase/index.tsx
@@ -4,19 +4,15 @@ import { useRefStore } from './stores/refs'
 import { useItemStore } from './stores/items'
 import { StagedRef, CompleteRef, Item, ExpandedItem } from './stores/types'
 
-const addToProfile: ((
+const addToProfile: (
   stagedRef: StagedRef | CompleteRef,
   attach: boolean,
-  options: { comment?: string; backlog?: boolean; list?: boolean },
-) => Promise<ExpandedItem>) = async (
-  stagedRef,
-  attach = true,
-  options = {}
-) => {
+  options: { text?: string; backlog?: boolean; list?: boolean }
+) => Promise<ExpandedItem> = async (stagedRef, attach = true, options = {}) => {
   if ((!pocketbase.authStore?.isValid || !pocketbase.authStore?.record) && attach)
     throw new Error('Not enough permissions')
 
-  console.log('WE GOT STAGED', "list" in stagedRef ? stagedRef.list : null)
+  console.log('WE GOT STAGED', 'list' in stagedRef ? stagedRef.list : null)
   console.log('WE GOT OPTIONS', options.list)
 
   const refStore = useRefStore.getState()
@@ -32,7 +28,7 @@ const addToProfile: ((
       ref: existingRef.id,
       image: existingRef?.image,
       creator: pocketbase.authStore?.record?.id,
-      text: options.comment,
+      text: options.text,
       backlog: !!options.backlog,
     })
   } else {
@@ -42,7 +38,7 @@ const addToProfile: ((
       ref: newRef.id,
       image: newRef.image,
       creator: pocketbase.authStore?.record?.id || '',
-      text: options.comment,
+      text: options.text,
       backlog: !!options.backlog,
       list: !!options.list,
     })

--- a/features/pocketbase/index.tsx
+++ b/features/pocketbase/index.tsx
@@ -6,18 +6,13 @@ import { StagedRef, CompleteRef, Item, ExpandedItem } from './stores/types'
 
 const addToProfile: (
   stagedRef: StagedRef | CompleteRef,
-  attach: boolean,
   options: { text?: string; backlog?: boolean; list?: boolean }
-) => Promise<ExpandedItem> = async (stagedRef, attach = true, options = {}) => {
-  if ((!pocketbase.authStore?.isValid || !pocketbase.authStore?.record) && attach)
-    throw new Error('Not enough permissions')
-
+) => Promise<ExpandedItem> = async (stagedRef, options = {}) => {
   console.log('WE GOT STAGED', 'list' in stagedRef ? stagedRef.list : null)
   console.log('WE GOT OPTIONS', options.list)
 
   const refStore = useRefStore.getState()
   const itemStore = useItemStore.getState()
-  const userStore = useUserStore.getState()
 
   let newItem: ExpandedItem
 
@@ -42,14 +37,6 @@ const addToProfile: (
       backlog: !!options.backlog,
       list: !!options.list,
     })
-  }
-
-  // If the userProfile is set, attach item ID to items
-  if (attach) {
-    await userStore.attachItem(newItem.id)
-  } else if (userStore.stagedUser) {
-    const items = userStore.stagedUser.items || []
-    await userStore.updateStagedUser({ items: [...items, newItem.id] })
   }
 
   return newItem

--- a/ui/actions/NewRef.tsx
+++ b/ui/actions/NewRef.tsx
@@ -70,28 +70,12 @@ export const NewRef = ({
     setStep('add')
   }
 
-  const handleNewRefCreated = (item: ExpandedItem, addToList: boolean = false) => {
+  const handleNewRefCreated = (item: ExpandedItem) => {
     console.log('HANDLE NEW REF CREATED', item.expand.ref.title)
     if (!item.expand?.ref)
       throw new Error('unexpected: handleNewRefCreated should always be called with ExpandedItem')
     setItemData(item)
     setRefData(item.expand?.ref)
-
-    if (addToList) {
-      console.log('edit list')
-      setStep('addToList')
-      console.log(itemData)
-    } else {
-      // Just complete the flow
-      if (!isProfile(user) || !user.userName) {
-        onCancel()
-      } else {
-        onNewRef(item)
-      }
-      setStep('')
-      setItemData(null)
-      setRefData({})
-    }
   }
 
   useEffect(() => {

--- a/ui/actions/NewRef.tsx
+++ b/ui/actions/NewRef.tsx
@@ -23,7 +23,7 @@ import * as Clipboard from 'expo-clipboard'
 import { Heading } from '../typo/Heading'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
-export type NewRefStep = '' | 'add' | 'search' | 'editList' | 'addToList' | 'categorise'
+export type NewRefStep = '' | 'add' | 'search' | 'editList' | 'addToList'
 
 const win = Dimensions.get('window')
 

--- a/ui/actions/NewRef.tsx
+++ b/ui/actions/NewRef.tsx
@@ -175,11 +175,6 @@ export const NewRef = ({
               text: fields.text,
               backlog,
             })
-            console.log('HANDLE NEW REF CREATED', newItem.expand.ref.title)
-            if (!newItem.expand?.ref)
-              throw new Error(
-                'unexpected: handleNewRefCreated should always be called with ExpandedItem'
-              )
             setItemData(newItem)
             setRefData(newItem.expand?.ref)
           }}

--- a/ui/actions/NewRef.tsx
+++ b/ui/actions/NewRef.tsx
@@ -170,6 +170,7 @@ export const NewRef = ({
         <RefForm
           r={refData}
           pickerOpen={pickerOpen}
+          canEditRefData={true}
           onAddRef={async (fields) => {
             await addToProfile(refData, {
               image: fields.image,

--- a/ui/actions/NewRef.tsx
+++ b/ui/actions/NewRef.tsx
@@ -171,6 +171,7 @@ export const NewRef = ({
           pickerOpen={pickerOpen}
           submitRef={async (fields) => {
             const newItem = await addToProfile(refData, {
+              image: fields.image,
               text: fields.text,
               backlog,
             })

--- a/ui/actions/NewRef.tsx
+++ b/ui/actions/NewRef.tsx
@@ -22,6 +22,7 @@ import { pocketbase } from '@/features/pocketbase/pocketbase'
 import * as Clipboard from 'expo-clipboard'
 import { Heading } from '../typo/Heading'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
+import { addToProfile } from '@/features/pocketbase'
 
 export type NewRefStep = '' | 'add' | 'search' | 'editList' | 'addToList'
 
@@ -68,14 +69,6 @@ export const NewRef = ({
     console.log(newRef)
     setRefData(newRef)
     setStep('add')
-  }
-
-  const handleNewRefCreated = (item: ExpandedItem) => {
-    console.log('HANDLE NEW REF CREATED', item.expand.ref.title)
-    if (!item.expand?.ref)
-      throw new Error('unexpected: handleNewRefCreated should always be called with ExpandedItem')
-    setItemData(item)
-    setRefData(item.expand?.ref)
   }
 
   useEffect(() => {
@@ -176,8 +169,19 @@ export const NewRef = ({
         <RefForm
           r={refData}
           pickerOpen={pickerOpen}
-          onComplete={handleNewRefCreated}
-          onCancel={() => setRefData({})}
+          submitRef={async (fields) => {
+            const newItem = await addToProfile(refData, {
+              text: fields.text,
+              backlog,
+            })
+            console.log('HANDLE NEW REF CREATED', newItem.expand.ref.title)
+            if (!newItem.expand?.ref)
+              throw new Error(
+                'unexpected: handleNewRefCreated should always be called with ExpandedItem'
+              )
+            setItemData(newItem)
+            setRefData(newItem.expand?.ref)
+          }}
           backlog={backlog}
         />
       )}

--- a/ui/actions/NewRef.tsx
+++ b/ui/actions/NewRef.tsx
@@ -169,14 +169,28 @@ export const NewRef = ({
         <RefForm
           r={refData}
           pickerOpen={pickerOpen}
-          submitRef={async (fields) => {
+          onAddRef={async (fields) => {
+            await addToProfile(refData, {
+              image: fields.image,
+              text: fields.text,
+              backlog,
+              list: false,
+            })
+            // finish the flow
+            setStep('')
+            setItemData(null)
+            setRefData({})
+          }}
+          onAddRefToList={async (fields) => {
             const newItem = await addToProfile(refData, {
               image: fields.image,
               text: fields.text,
               backlog,
+              list: true,
             })
             setItemData(newItem)
             setRefData(newItem.expand?.ref)
+            setStep('addToList')
           }}
           backlog={backlog}
         />

--- a/ui/actions/RefForm.tsx
+++ b/ui/actions/RefForm.tsx
@@ -46,7 +46,7 @@ export const RefForm = ({
   // Separate state for each field to prevent unnecessary re-renders
   const [title, setTitle] = useState<string>(r?.title || '')
   const [url, setUrl] = useState<string>(r?.url || '')
-  const [comment, setComment] = useState<string>('')
+  const [text, setText] = useState<string>('')
   const [imageAsset, setImageAsset] = useState<ImagePickerAsset | null>(null)
   const [pinataSource, setPinataSource] = useState<string>('')
   const [picking, setPicking] = useState(pickerOpen)
@@ -160,7 +160,7 @@ export const RefForm = ({
       setCreateInProgress(true)
       const attach = !pathname.includes('onboarding') && !willAddToList
       const item = await addToProfile(data, attach, {
-        comment,
+        text,
         backlog,
         ...extraFields,
       })
@@ -428,7 +428,7 @@ export const RefForm = ({
           numberOfLines={4}
           placeholder="Add a caption for your profile"
           placeholderTextColor={c.muted}
-          onChangeText={setComment}
+          onChangeText={setText}
           style={{
             backgroundColor: c.white,
             borderRadius: s.$075,

--- a/ui/actions/RefForm.tsx
+++ b/ui/actions/RefForm.tsx
@@ -27,12 +27,20 @@ const win = Dimensions.get('window')
 export const RefForm = ({
   r,
   placeholder = 'Add a title',
-  submitRef,
+  onAddRef,
+  onAddRefToList,
   pickerOpen = false,
 }: {
   r: StagedRef
   placeholder?: string
-  submitRef: (fields: {
+  onAddRef: (fields: {
+    title: string
+    text: string
+    url: string
+    image: string
+    meta?: string
+  }) => Promise<void>
+  onAddRefToList: (fields: {
     title: string
     text: string
     url: string
@@ -62,14 +70,11 @@ export const RefForm = ({
 
   // Initialize state based on incoming ref
   useEffect(() => {
-    console.log(r)
     if (r?.title) setTitle(r.title)
     if (r?.url) setUrl(r.url)
 
     // Initialize image state
     if (r?.image) {
-      console.log('image found')
-      console.log(r.image)
       if (typeof r.image === 'string') {
         setPinataSource(r.image)
       } else {
@@ -77,10 +82,6 @@ export const RefForm = ({
       }
     }
   }, [r])
-
-  const handleTitleChange = (newTitle: string) => {
-    setTitle(newTitle)
-  }
 
   const handleImageSuccess = (imageUrl: string) => {
     setUploadInProgress(false)
@@ -132,25 +133,6 @@ export const RefForm = ({
       isValid = false
     }
     return isValid
-  }
-
-  const submit = async () => {
-    // Only include meta if location or author is present
-    let meta: string | undefined = undefined
-    if (location || author) {
-      meta = JSON.stringify({ location, author })
-    }
-
-    try {
-      setCreateInProgress(true)
-      await submitRef({ title, text, url, image: pinataSource, meta })
-      console.log('success')
-    } catch (e) {
-      console.error(e)
-    } finally {
-      setCreateInProgress(false)
-      console.log('Done')
-    }
   }
 
   return (
@@ -277,8 +259,9 @@ export const RefForm = ({
           }}
         >
           <EditableHeader
-            onTitleChange={handleTitleChange}
-            onDataChange={handleDataChange}
+            setTitle={setTitle}
+            setUrl={setUrl}
+            setImage={setPinataSource}
             placeholder={placeholder}
             title={title}
             url={url || ''}
@@ -431,11 +414,26 @@ export const RefForm = ({
             variant="whiteOutline"
             style={{ width: '48%', minWidth: 0 }}
             disabled={!title || createInProgress}
-            onPress={() => {
+            onPress={async () => {
               if (!validateFields()) {
                 return
               }
-              submit()
+              // Only include meta if location or author is present
+              let meta: string | undefined = undefined
+              if (location || author) {
+                meta = JSON.stringify({ location, author })
+              }
+
+              try {
+                setCreateInProgress(true)
+                await onAddRefToList({ title, text, url, image: pinataSource, meta })
+                console.log('success')
+              } catch (e) {
+                console.error(e)
+              } finally {
+                setCreateInProgress(false)
+                console.log('Done')
+              }
             }}
           />
           {createInProgress || uploadInProgress || (uploadInitiated && !pinataSource) ? (
@@ -463,11 +461,27 @@ export const RefForm = ({
               variant="whiteInverted"
               style={{ width: '48%', minWidth: 0 }}
               disabled={!(pinataSource && title) || createInProgress}
-              onPress={() => {
+              onPress={async () => {
                 if (!validateFields()) {
                   return
                 }
-                submit()
+
+                // Only include meta if location or author is present
+                let meta: string | undefined = undefined
+                if (location || author) {
+                  meta = JSON.stringify({ location, author })
+                }
+
+                try {
+                  setCreateInProgress(true)
+                  await onAddRef({ title, text, url, image: pinataSource, meta })
+                  console.log('success')
+                } catch (e) {
+                  console.error(e)
+                } finally {
+                  setCreateInProgress(false)
+                  console.log('Done')
+                }
               }}
             />
           )}

--- a/ui/actions/RefForm.tsx
+++ b/ui/actions/RefForm.tsx
@@ -118,19 +118,21 @@ export const RefForm = ({
     ]).start()
   }
 
-  const submit = async () => {
+  const validateFields = () => {
     // Check for missing fields
-    let missing = false
+    let isValid = true
     if (!title) {
       triggerShake(titleShake)
-      missing = true
+      isValid = false
     }
     if (!pinataSource) {
       triggerShake(imageShake)
-      missing = true
+      isValid = false
     }
-    if (missing) return
+    return isValid
+  }
 
+  const submit = async () => {
     // Only include meta if location or author is present
     let meta: string | undefined = undefined
     if (location || author) {
@@ -441,6 +443,9 @@ export const RefForm = ({
             style={{ width: '48%', minWidth: 0 }}
             disabled={!title || createInProgress}
             onPress={() => {
+              if (!validateFields()) {
+                return
+              }
               submit()
             }}
           />
@@ -469,7 +474,12 @@ export const RefForm = ({
               variant="whiteInverted"
               style={{ width: '48%', minWidth: 0 }}
               disabled={!(pinataSource && title) || createInProgress}
-              onPress={() => submit()}
+              onPress={() => {
+                if (!validateFields()) {
+                  return
+                }
+                submit()
+              }}
             />
           )}
         </View>

--- a/ui/actions/RefForm.tsx
+++ b/ui/actions/RefForm.tsx
@@ -35,7 +35,7 @@ export const RefForm = ({
 }: {
   r: StagedRef
   placeholder?: string
-  onComplete: (i: ExpandedItem, p: boolean) => void
+  onComplete: (i: ExpandedItem) => void
   onCancel: () => void
   pickerOpen?: boolean
   backlog?: boolean
@@ -118,7 +118,7 @@ export const RefForm = ({
     ]).start()
   }
 
-  const submit = async (extraFields?: Partial<ExpandedItem>, promptList = false) => {
+  const submit = async () => {
     // Check for missing fields
     let missing = false
     if (!title) {
@@ -144,7 +144,6 @@ export const RefForm = ({
       image: pinataSource,
       backlog,
       meta,
-      ...extraFields,
     }
 
     try {
@@ -152,9 +151,8 @@ export const RefForm = ({
       const item = await addToProfile(data, {
         text,
         backlog,
-        ...extraFields,
       })
-      onComplete(item, promptList)
+      onComplete(item)
       setCreateInProgress(false)
       console.log('success')
     } catch (e) {
@@ -443,7 +441,7 @@ export const RefForm = ({
             style={{ width: '48%', minWidth: 0 }}
             disabled={!title || createInProgress}
             onPress={() => {
-              submit({}, true)
+              submit()
             }}
           />
           {createInProgress || uploadInProgress || (uploadInitiated && !pinataSource) ? (

--- a/ui/actions/RefForm.tsx
+++ b/ui/actions/RefForm.tsx
@@ -30,6 +30,7 @@ export const RefForm = ({
   onAddRef,
   onAddRefToList,
   pickerOpen = false,
+  canEditRefData = true,
 }: {
   r: StagedRef
   placeholder?: string
@@ -49,6 +50,7 @@ export const RefForm = ({
   }) => Promise<void>
   pickerOpen?: boolean
   backlog?: boolean
+  canEditRefData?: boolean
 }) => {
   // Separate state for each field to prevent unnecessary re-renders
   const [title, setTitle] = useState<string>(r?.title || '')
@@ -70,8 +72,8 @@ export const RefForm = ({
 
   // Initialize state based on incoming ref
   useEffect(() => {
-    if (r?.title) setTitle(r.title)
-    if (r?.url) setUrl(r.url)
+    setTitle(r.title || '')
+    setUrl(r.url || '')
 
     // Initialize image state
     if (r?.image) {
@@ -80,6 +82,9 @@ export const RefForm = ({
       } else {
         setImageAsset(r.image)
       }
+    } else {
+      setPinataSource('')
+      setImageAsset(null)
     }
   }, [r])
 
@@ -101,14 +106,6 @@ export const RefForm = ({
       setUploadInitiated(false)
     }
   }, [uploadInitiated, pinataSource, title])
-
-  const handleDataChange = (d: { title: string; url: string; image?: string | undefined }) => {
-    setTitle(d.title)
-    setUrl(d.url)
-    if (d.image) {
-      setPinataSource(d.image)
-    }
-  }
 
   // Shake animation function
   const triggerShake = (anim: Animated.Value) => {
@@ -238,148 +235,170 @@ export const RefForm = ({
           />
         )}
 
-        <Animated.View
-          style={{
-            width: '100%',
-            marginBottom: 0,
-            transform: [
-              {
-                translateX: titleShake.interpolate({
-                  inputRange: [-1, 0, 1],
-                  outputRange: [-10, 0, 10],
-                }),
-              },
-              {
-                scale: titleShake.interpolate({
-                  inputRange: [-1, 0, 1],
-                  outputRange: [1.05, 1, 1.05],
-                }),
-              },
-            ],
-          }}
-        >
-          <EditableHeader
-            setTitle={setTitle}
-            setUrl={setUrl}
-            setImage={setPinataSource}
-            placeholder={placeholder}
-            title={title}
-            url={url || ''}
-            image={pinataSource}
-          />
-        </Animated.View>
+        {canEditRefData ? (
+          <Animated.View
+            style={{
+              width: '100%',
+              marginBottom: 0,
+              transform: [
+                {
+                  translateX: titleShake.interpolate({
+                    inputRange: [-1, 0, 1],
+                    outputRange: [-10, 0, 10],
+                  }),
+                },
+                {
+                  scale: titleShake.interpolate({
+                    inputRange: [-1, 0, 1],
+                    outputRange: [1.05, 1, 1.05],
+                  }),
+                },
+              ],
+            }}
+          >
+            <EditableHeader
+              setTitle={setTitle}
+              setUrl={setUrl}
+              setImage={setPinataSource}
+              placeholder={placeholder}
+              title={title}
+              url={url || ''}
+              image={pinataSource}
+            />
+          </Animated.View>
+        ) : (
+          <View style={{ width: '100%', marginBottom: 0 }}>
+            <Heading tag="h1" style={{ color: c.surface }}>
+              {title}
+            </Heading>
+            {/* TODO: figure out how to display the url here */}
+            {/* <Heading tag="h2" style={{ color: c.surface }}>
+              {url}
+            </Heading> */}
+          </View>
+        )}
 
         {/* Inline subtitle row for location/author, now directly below title with minimal spacing */}
         <View style={{ width: '100%', alignItems: 'flex-start', marginTop: -17, marginBottom: 2 }}>
           {/* Only show one: location or author, never both */}
-          {editingField === 'location' ? (
-            <TextInput
-              value={location}
-              onChangeText={(t) => t.length <= 150 && setLocation(t)}
-              onBlur={() => setEditingField(null)}
-              autoFocus
-              placeholder="Add location"
-              style={{
-                minWidth: 80,
-                maxWidth: 250,
-                color: c.surface,
-                fontSize: 18,
-                fontWeight: '600',
-                opacity: 0.5,
-                backgroundColor: 'transparent',
-                padding: 0,
-                margin: 0,
-                textAlign: 'left',
-              }}
-              maxLength={150}
-              returnKeyType="done"
-            />
-          ) : editingField === 'author' ? (
-            <TextInput
-              value={author}
-              onChangeText={(t) => t.length <= 150 && setAuthor(t)}
-              onBlur={() => setEditingField(null)}
-              autoFocus
-              placeholder="Add author"
-              style={{
-                minWidth: 80,
-                maxWidth: 250,
-                color: c.surface,
-                fontSize: 18,
-                fontWeight: '600',
-                opacity: 0.5,
-                backgroundColor: 'transparent',
-                padding: 0,
-                margin: 0,
-                textAlign: 'left',
-              }}
-              maxLength={150}
-              returnKeyType="done"
-            />
-          ) : location ? (
-            <Pressable
-              onPress={() => {
-                setTimeout(() => setEditingField('location'), 0)
-              }}
-            >
-              <Text
+          {canEditRefData ? (
+            editingField === 'location' ? (
+              <TextInput
+                value={location}
+                onChangeText={(t) => t.length <= 150 && setLocation(t)}
+                onBlur={() => setEditingField(null)}
+                autoFocus
+                placeholder="Add location"
                 style={{
+                  minWidth: 80,
+                  maxWidth: 250,
                   color: c.surface,
                   fontSize: 18,
                   fontWeight: '600',
                   opacity: 0.5,
+                  backgroundColor: 'transparent',
+                  padding: 0,
+                  margin: 0,
                   textAlign: 'left',
                 }}
-              >
-                {location}
-              </Text>
-            </Pressable>
-          ) : author ? (
-            <Pressable
-              onPress={() => {
-                setTimeout(() => setEditingField('author'), 0)
-              }}
-            >
-              <Text
+                maxLength={150}
+                returnKeyType="done"
+              />
+            ) : editingField === 'author' ? (
+              <TextInput
+                value={author}
+                onChangeText={(t) => t.length <= 150 && setAuthor(t)}
+                onBlur={() => setEditingField(null)}
+                autoFocus
+                placeholder="Add author"
                 style={{
+                  minWidth: 80,
+                  maxWidth: 250,
                   color: c.surface,
                   fontSize: 18,
                   fontWeight: '600',
                   opacity: 0.5,
+                  backgroundColor: 'transparent',
+                  padding: 0,
+                  margin: 0,
                   textAlign: 'left',
                 }}
+                maxLength={150}
+                returnKeyType="done"
+              />
+            ) : location ? (
+              <Pressable
+                onPress={() => {
+                  setTimeout(() => setEditingField('location'), 0)
+                }}
               >
-                {author}
-              </Text>
-            </Pressable>
+                <Text
+                  style={{
+                    color: c.surface,
+                    fontSize: 18,
+                    fontWeight: '600',
+                    opacity: 0.5,
+                    textAlign: 'left',
+                  }}
+                >
+                  {location}
+                </Text>
+              </Pressable>
+            ) : author ? (
+              <Pressable
+                onPress={() => {
+                  setTimeout(() => setEditingField('author'), 0)
+                }}
+              >
+                <Text
+                  style={{
+                    color: c.surface,
+                    fontSize: 18,
+                    fontWeight: '600',
+                    opacity: 0.5,
+                    textAlign: 'left',
+                  }}
+                >
+                  {author}
+                </Text>
+              </Pressable>
+            ) : (
+              <View style={{ flexDirection: 'row', gap: 16 }}>
+                <Pressable onPress={() => setEditingField('location')}>
+                  <Text
+                    style={{
+                      color: c.surface,
+                      fontSize: 17.6,
+                      opacity: 0.7,
+                      textAlign: 'left',
+                      fontWeight: '600',
+                    }}
+                  >
+                    + location
+                  </Text>
+                </Pressable>
+                <Pressable onPress={() => setEditingField('author')}>
+                  <Text
+                    style={{
+                      color: c.surface,
+                      fontSize: 17.6,
+                      opacity: 0.7,
+                      textAlign: 'left',
+                      fontWeight: '600',
+                    }}
+                  >
+                    + author
+                  </Text>
+                </Pressable>
+              </View>
+            )
           ) : (
-            <View style={{ flexDirection: 'row', gap: 16 }}>
-              <Pressable onPress={() => setEditingField('location')}>
-                <Text
-                  style={{
-                    color: c.surface,
-                    fontSize: 17.6,
-                    opacity: 0.7,
-                    textAlign: 'left',
-                    fontWeight: '600',
-                  }}
-                >
-                  + location
-                </Text>
-              </Pressable>
-              <Pressable onPress={() => setEditingField('author')}>
-                <Text
-                  style={{
-                    color: c.surface,
-                    fontSize: 17.6,
-                    opacity: 0.7,
-                    textAlign: 'left',
-                    fontWeight: '600',
-                  }}
-                >
-                  + author
-                </Text>
-              </Pressable>
+            <View
+              style={{ width: '100%', alignItems: 'flex-start', marginTop: -17, marginBottom: 2 }}
+            >
+              <Heading tag="h2" style={{ color: c.surface }}>
+                {location || author}
+              </Heading>
             </View>
           )}
         </View>

--- a/ui/actions/RefForm.tsx
+++ b/ui/actions/RefForm.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useRef } from 'react'
-import { usePathname } from 'expo-router'
 import {
   View,
   TouchableOpacity,
@@ -33,7 +32,6 @@ export const RefForm = ({
   onCancel,
   backlog = false,
   pickerOpen = false,
-  attach = true,
 }: {
   r: StagedRef
   placeholder?: string
@@ -41,7 +39,6 @@ export const RefForm = ({
   onCancel: () => void
   pickerOpen?: boolean
   backlog?: boolean
-  attach?: boolean
 }) => {
   // Separate state for each field to prevent unnecessary re-renders
   const [title, setTitle] = useState<string>(r?.title || '')
@@ -56,8 +53,6 @@ export const RefForm = ({
   const [location, setLocation] = useState<string>('')
   const [author, setAuthor] = useState<string>('')
   const [editingField, setEditingField] = useState<'location' | 'author' | null>(null)
-
-  const pathname = usePathname()
 
   // Animation refs
   const titleShake = useRef(new Animated.Value(0)).current
@@ -123,11 +118,7 @@ export const RefForm = ({
     ]).start()
   }
 
-  const submit = async (
-    willAddToList: boolean,
-    extraFields?: Partial<ExpandedItem>,
-    promptList = false
-  ) => {
+  const submit = async (extraFields?: Partial<ExpandedItem>, promptList = false) => {
     // Check for missing fields
     let missing = false
     if (!title) {
@@ -158,8 +149,7 @@ export const RefForm = ({
 
     try {
       setCreateInProgress(true)
-      const attach = !pathname.includes('onboarding') && !willAddToList
-      const item = await addToProfile(data, attach, {
+      const item = await addToProfile(data, {
         text,
         backlog,
         ...extraFields,
@@ -453,7 +443,7 @@ export const RefForm = ({
             style={{ width: '48%', minWidth: 0 }}
             disabled={!title || createInProgress}
             onPress={() => {
-              submit(true, {}, true)
+              submit({}, true)
             }}
           />
           {createInProgress || uploadInProgress || (uploadInitiated && !pinataSource) ? (
@@ -481,7 +471,7 @@ export const RefForm = ({
               variant="whiteInverted"
               style={{ width: '48%', minWidth: 0 }}
               disabled={!(pinataSource && title) || createInProgress}
-              onPress={() => submit(false)}
+              onPress={() => submit()}
             />
           )}
         </View>

--- a/ui/actions/RefForm.tsx
+++ b/ui/actions/RefForm.tsx
@@ -153,11 +153,11 @@ export const RefForm = ({
         backlog,
       })
       onComplete(item)
-      setCreateInProgress(false)
       console.log('success')
     } catch (e) {
       console.error(e)
     } finally {
+      setCreateInProgress(false)
       console.log('Done')
     }
   }

--- a/ui/actions/RefForm.tsx
+++ b/ui/actions/RefForm.tsx
@@ -41,7 +41,7 @@ export const RefForm = ({
     image: string
     meta?: string
   }) => Promise<void>
-  onAddRefToList: (fields: {
+  onAddRefToList?: (fields: {
     title: string
     text: string
     url: string
@@ -434,6 +434,9 @@ export const RefForm = ({
             style={{ width: '48%', minWidth: 0 }}
             disabled={!title || createInProgress}
             onPress={async () => {
+              if (!onAddRefToList) {
+                return
+              }
               if (!validateFields()) {
                 return
               }
@@ -455,6 +458,7 @@ export const RefForm = ({
               }
             }}
           />
+
           {createInProgress || uploadInProgress || (uploadInitiated && !pinataSource) ? (
             <Pressable
               style={{

--- a/ui/actions/RefForm.tsx
+++ b/ui/actions/RefForm.tsx
@@ -235,48 +235,37 @@ export const RefForm = ({
           />
         )}
 
-        {canEditRefData ? (
-          <Animated.View
-            style={{
-              width: '100%',
-              marginBottom: 0,
-              transform: [
-                {
-                  translateX: titleShake.interpolate({
-                    inputRange: [-1, 0, 1],
-                    outputRange: [-10, 0, 10],
-                  }),
-                },
-                {
-                  scale: titleShake.interpolate({
-                    inputRange: [-1, 0, 1],
-                    outputRange: [1.05, 1, 1.05],
-                  }),
-                },
-              ],
-            }}
-          >
-            <EditableHeader
-              setTitle={setTitle}
-              setUrl={setUrl}
-              setImage={setPinataSource}
-              placeholder={placeholder}
-              title={title}
-              url={url || ''}
-              image={pinataSource}
-            />
-          </Animated.View>
-        ) : (
-          <View style={{ width: '100%', marginBottom: 0 }}>
-            <Heading tag="h1" style={{ color: c.surface }}>
-              {title}
-            </Heading>
-            {/* TODO: figure out how to display the url here */}
-            {/* <Heading tag="h2" style={{ color: c.surface }}>
-              {url}
-            </Heading> */}
-          </View>
-        )}
+        <Animated.View
+          style={{
+            width: '100%',
+            marginBottom: 0,
+            transform: [
+              {
+                translateX: titleShake.interpolate({
+                  inputRange: [-1, 0, 1],
+                  outputRange: [-10, 0, 10],
+                }),
+              },
+              {
+                scale: titleShake.interpolate({
+                  inputRange: [-1, 0, 1],
+                  outputRange: [1.05, 1, 1.05],
+                }),
+              },
+            ],
+          }}
+        >
+          <EditableHeader
+            canEditRefData={canEditRefData}
+            setTitle={setTitle}
+            setUrl={setUrl}
+            setImage={setPinataSource}
+            placeholder={placeholder}
+            title={title}
+            url={url || ''}
+            image={pinataSource}
+          />
+        </Animated.View>
 
         {/* Inline subtitle row for location/author, now directly below title with minimal spacing */}
         <View style={{ width: '100%', alignItems: 'flex-start', marginTop: -17, marginBottom: 2 }}>

--- a/ui/actions/RefForm.tsx
+++ b/ui/actions/RefForm.tsx
@@ -14,11 +14,10 @@ import { Picker } from '../inputs/Picker'
 import { PinataImage } from '../images/PinataImage'
 import { Image } from 'expo-image'
 import { EditableHeader } from '../atoms/EditableHeader'
-import { addToProfile } from '@/features/pocketbase'
 import { Button } from '../buttons/Button'
 import type { ImagePickerAsset } from 'expo-image-picker'
 import { c, s } from '@/features/style'
-import { StagedRef, ExpandedItem } from '@/features/pocketbase/stores/types'
+import { StagedRef } from '@/features/pocketbase/stores/types'
 // @ts-ignore
 import { KeyboardAvoidingView } from 'react-native-keyboard-controller'
 import { DismissKeyboard } from '../atoms/DismissKeyboard'
@@ -28,15 +27,18 @@ const win = Dimensions.get('window')
 export const RefForm = ({
   r,
   placeholder = 'Add a title',
-  onComplete,
-  onCancel,
-  backlog = false,
+  submitRef,
   pickerOpen = false,
 }: {
   r: StagedRef
   placeholder?: string
-  onComplete: (i: ExpandedItem) => void
-  onCancel: () => void
+  submitRef: (fields: {
+    title: string
+    text: string
+    url: string
+    image: string
+    meta?: string
+  }) => Promise<void>
   pickerOpen?: boolean
   backlog?: boolean
 }) => {
@@ -139,22 +141,9 @@ export const RefForm = ({
       meta = JSON.stringify({ location, author })
     }
 
-    const data = {
-      ...r,
-      title,
-      url,
-      image: pinataSource,
-      backlog,
-      meta,
-    }
-
     try {
       setCreateInProgress(true)
-      const item = await addToProfile(data, {
-        text,
-        backlog,
-      })
-      onComplete(item)
+      await submitRef({ title, text, url, image: pinataSource, meta })
       console.log('success')
     } catch (e) {
       console.error(e)

--- a/ui/atoms/EditableHeader.tsx
+++ b/ui/atoms/EditableHeader.tsx
@@ -10,26 +10,25 @@ import { getLinkPreview } from 'link-preview-js'
 
 export const EditableHeader = ({
   title,
+  setTitle,
   url,
+  setUrl,
   image,
+  setImage,
   placeholder = '',
   initialEditing = false,
   withUrl = true,
-  onTitleChange = () => {},
-  onDataChange = () => {},
 }: {
   title: string
+  setTitle: (str: string) => void
   url: string
+  setUrl: (str: string) => void
   image?: string
+  setImage: (str: string) => void
   placeholder: string
   initialEditing?: boolean
   withUrl?: boolean
-  onTitleChange: (str: string) => void
-  onDataChange: (d: { url: string; image?: string; title: string }) => void
 }) => {
-  const [titleState, setTitleState] = useState(title || '')
-  const [urlState, setUrlState] = useState(url)
-  const [imageState, setImageState] = useState(image)
   const [hasUrl, setHasUrl] = useState(false)
   const [editing, setEditing] = useState(initialEditing)
   const [addingUrl, setAddingUrl] = useState(false)
@@ -38,15 +37,15 @@ export const EditableHeader = ({
     // pass the link directly
     getLinkPreview(u).then((data) => {
       // @ts-ignore
-      if (data?.title && titleState === '') {
+      if (data?.title && title === '') {
         // @ts-ignore
         console.log('SETTING TITLE: ', data.title)
         // @ts-ignore
-        setTitleState(data.title)
+        setTitle(data.title)
       }
 
       // @ts-ignore
-      if (data?.images?.length > 0 && !imageState) {
+      if (data?.images?.length > 0 && !image) {
         // @ts-ignore
         console.log('IMAGE', data.images[0])
         // @ts-ignore
@@ -56,18 +55,8 @@ export const EditableHeader = ({
   }
 
   useEffect(() => {
-    // make sure that if an image was uploaded, EditableHeader knows about it
-    // and won't overwrite it with an image from the url
-    if (image) setImageState(image)
-  }, [image])
-
-  useEffect(() => {
-    onDataChange({ title: titleState, url: urlState, image: imageState })
-  }, [titleState, imageState, urlState])
-
-  useEffect(() => {
-    if (urlState && urlState !== '') analyseUrl(urlState)
-  }, [urlState])
+    if (url && url !== '') analyseUrl(url)
+  }, [url])
 
   useEffect(() => {
     const detectUrl = async () => {
@@ -106,10 +95,10 @@ export const EditableHeader = ({
                   textAlign: 'left',
                   color: c.surface,
                   fontSize: 24,
-                  opacity: titleState ? 1 : 0.7,
+                  opacity: title ? 1 : 0.7,
                 }}
               >
-                {titleState || placeholder}
+                {title || placeholder}
               </Heading>
             </Pressable>
           </XStack>
@@ -128,15 +117,14 @@ export const EditableHeader = ({
               },
             ]}
             autoFocus={true}
-            value={titleState == placeholder ? '' : titleState}
+            value={title == placeholder ? '' : title}
             placeholder={placeholder}
             onChangeText={(e) => {
-              setTitleState(e)
+              setTitle(e)
             }}
             multiline={true}
             onBlur={() => {
               setEditing(false)
-              onTitleChange(titleState)
             }}
           ></TextInput>
         )}
@@ -152,13 +140,13 @@ export const EditableHeader = ({
               borderRadius: s.$075,
               color: c.muted,
             }}
-            value={urlState}
+            value={url}
             autoFocus={true}
             autoCorrect={false}
             autoCapitalize="none"
             autoComplete="off"
             placeholder="Paste url"
-            onChangeText={setUrlState}
+            onChangeText={setUrl}
             clearButtonMode="while-editing"
           />
         )}
@@ -174,7 +162,6 @@ export const EditableHeader = ({
             <Pressable
               onPress={() => {
                 setEditing(false)
-                onTitleChange(titleState)
               }}
             >
               <Ionicons size={28} name="checkbox-outline" color={c.surface2} />
@@ -191,7 +178,7 @@ export const EditableHeader = ({
               >
                 <Ionicons
                   size={24}
-                  name={titleState === 'placeholder' || titleState === '' ? 'add' : 'pencil'}
+                  name={title === 'placeholder' || title === '' ? 'add' : 'pencil'}
                   color={c.white}
                 />
               </Pressable>
@@ -206,17 +193,13 @@ export const EditableHeader = ({
               }}
               onPress={() => setAddingUrl(true)}
             >
-              <Ionicons
-                name="link-outline"
-                size={28}
-                color={urlState === '' ? c.olive2 : c.white}
-              />
+              <Ionicons name="link-outline" size={28} color={url === '' ? c.olive2 : c.white} />
             </Pressable>
           )}
 
           {addingUrl && withUrl && (
             <>
-              {hasUrl && urlState === '' ? (
+              {hasUrl && url === '' ? (
                 <></>
               ) : (
                 <Pressable onPress={() => setAddingUrl(false)}>

--- a/ui/atoms/EditableHeader.tsx
+++ b/ui/atoms/EditableHeader.tsx
@@ -36,20 +36,14 @@ export const EditableHeader = ({
   const analyseUrl = async (u: string) => {
     // pass the link directly
     getLinkPreview(u).then((data) => {
-      // @ts-ignore
-      if (data?.title && title === '') {
-        // @ts-ignore
+      if ('title' in data && data?.title && title === '') {
         console.log('SETTING TITLE: ', data.title)
-        // @ts-ignore
         setTitle(data.title)
       }
 
-      // @ts-ignore
-      if (data?.images?.length > 0 && !image) {
-        // @ts-ignore
+      if ('images' in data && data?.images?.length > 0 && !image) {
         console.log('IMAGE', data.images[0])
-        // @ts-ignore
-        setImageState(data.images[0])
+        setImage(data.images[0])
       }
     })
   }

--- a/ui/atoms/EditableHeader.tsx
+++ b/ui/atoms/EditableHeader.tsx
@@ -9,6 +9,7 @@ import * as Clipboard from 'expo-clipboard'
 import { getLinkPreview } from 'link-preview-js'
 
 export const EditableHeader = ({
+  canEditRefData,
   title,
   setTitle,
   url,
@@ -16,9 +17,9 @@ export const EditableHeader = ({
   image,
   setImage,
   placeholder = '',
-  initialEditing = false,
   withUrl = true,
 }: {
+  canEditRefData: boolean
   title: string
   setTitle: (str: string) => void
   url: string
@@ -26,11 +27,10 @@ export const EditableHeader = ({
   image?: string
   setImage: (str: string) => void
   placeholder: string
-  initialEditing?: boolean
   withUrl?: boolean
 }) => {
   const [hasUrl, setHasUrl] = useState(false)
-  const [editing, setEditing] = useState(initialEditing)
+  const [editing, setEditing] = useState(false)
   const [addingUrl, setAddingUrl] = useState(false)
 
   const analyseUrl = async (u: string) => {
@@ -82,7 +82,11 @@ export const EditableHeader = ({
               alignItems: 'flex-start',
             }}
           >
-            <Pressable onPress={() => setEditing(true)}>
+            <Pressable
+              onPress={() => {
+                if (canEditRefData) setEditing(true)
+              }}
+            >
               <Heading
                 tag="h2"
                 style={{
@@ -161,14 +165,17 @@ export const EditableHeader = ({
               <Ionicons size={28} name="checkbox-outline" color={c.surface2} />
             </Pressable>
           ) : (
-            !addingUrl && (
+            !addingUrl &&
+            canEditRefData && (
               <Pressable
                 style={{
                   width: 28,
                   // backgroundColor: 'red',
                   flexShrink: 0,
                 }}
-                onPress={() => setEditing(true)}
+                onPress={() => {
+                  if (canEditRefData) setEditing(true)
+                }}
               >
                 <Ionicons
                   size={24}

--- a/ui/profiles/Details.tsx
+++ b/ui/profiles/Details.tsx
@@ -205,7 +205,7 @@ export const Details = ({ profile, data }: { profile: ExpandedProfile; data: Ite
       )}
 
       {/* add ref sheet */}
-      {itemToAdd && <AddRefSheet itemToAdd={itemToAdd} bottomSheetRef={addRefSheetRef} />}
+      <AddRefSheet itemToAdd={itemToAdd} bottomSheetRef={addRefSheetRef} />
     </>
   )
 }

--- a/ui/profiles/Details.tsx
+++ b/ui/profiles/Details.tsx
@@ -205,7 +205,7 @@ export const Details = ({ profile, data }: { profile: ExpandedProfile; data: Ite
       )}
 
       {/* add ref sheet */}
-      <AddRefSheet itemToAdd={itemToAdd} bottomSheetRef={addRefSheetRef} />
+      {itemToAdd && <AddRefSheet itemToAdd={itemToAdd} bottomSheetRef={addRefSheetRef} />}
     </>
   )
 }

--- a/ui/profiles/profileDetailsStore.tsx
+++ b/ui/profiles/profileDetailsStore.tsx
@@ -1,4 +1,4 @@
-import { createContext, ReactNode } from 'react'
+import { createContext, ReactNode, useState } from 'react'
 import { createStore, StoreApi } from 'zustand'
 
 type ProfileDetailsState = {
@@ -29,16 +29,18 @@ export const ProfileDetailsProvider = ({
   openedFromFeed: boolean
   editingRights: boolean
 }) => {
-  const profileDetailsStore = createStore<ProfileDetailsState>((set) => ({
-    currentIndex: initialIndex,
-    setCurrentIndex: (newCurrentIndex) => set({ currentIndex: newCurrentIndex }),
-    showContextMenu: false,
-    setShowContextMenu: (newShowContextMenu) => set({ showContextMenu: newShowContextMenu }),
-    isEditing: false,
-    setIsEditing: (newIsEditing) => set({ isEditing: newIsEditing }),
-    openedFromFeed,
-    editingRights,
-  }))
+  const [profileDetailsStore] = useState(() =>
+    createStore<ProfileDetailsState>((set) => ({
+      currentIndex: initialIndex,
+      setCurrentIndex: (newCurrentIndex) => set({ currentIndex: newCurrentIndex }),
+      showContextMenu: false,
+      setShowContextMenu: (newShowContextMenu) => set({ showContextMenu: newShowContextMenu }),
+      isEditing: false,
+      setIsEditing: (newIsEditing) => set({ isEditing: newIsEditing }),
+      openedFromFeed,
+      editingRights,
+    }))
+  )
 
   return (
     <ProfileDetailsContext.Provider value={profileDetailsStore}>

--- a/ui/profiles/sheets/AddRefSheet.tsx
+++ b/ui/profiles/sheets/AddRefSheet.tsx
@@ -12,6 +12,7 @@ import { Text, View } from 'react-native'
 import Animated, { FadeIn, FadeOut } from 'react-native-reanimated'
 import { AddRefSheetGrid } from './AddRefSheetGrid'
 import { useUIStore } from '@/ui/state'
+import { FilteredItems } from '@/ui/actions/FilteredItems'
 
 export const AddRefSheet = ({
   bottomSheetRef,
@@ -120,9 +121,7 @@ export const AddRefSheet = ({
           <RefForm
             r={refData}
             canEditRefData={false}
-            onAddRefToList={async (fields) => {
-              console.log('TODO: onAddRefToList')
-            }}
+            onAddRefToList={async (fields) => {}}
             onAddRef={async (fields) => {
               if (!user) return
               const gridItems = await getProfileItems(user.userName)

--- a/ui/profiles/sheets/AddRefSheet.tsx
+++ b/ui/profiles/sheets/AddRefSheet.tsx
@@ -113,7 +113,10 @@ export const AddRefSheet = ({
         <View style={{ padding: s.$3 }}>
           <RefForm
             r={itemToAdd?.expand.ref}
-            submitRef={async (fields) => {
+            onAddRefToList={async (fields) => {
+              console.log('TODO: onAddRefToList')
+            }}
+            onAddRef={async (fields) => {
               if (!user) return
               const gridItems = await getProfileItems(user.userName)
               setGridItems(gridItems)

--- a/ui/profiles/sheets/AddRefSheet.tsx
+++ b/ui/profiles/sheets/AddRefSheet.tsx
@@ -38,25 +38,34 @@ export const AddRefSheet = ({
   }, [])
 
   useEffect(() => {
-    const fetchGridItems = async () => {
-      if (!user) {
-        setGridItems([])
-      } else {
-        const gridItems = await getProfileItems(user.userName)
-        setGridItems(gridItems)
+    async function initialize() {
+      if (itemToAdd) {
+        if (user) {
+          const gridItems = await getProfileItems(user.userName)
+          setGridItems(gridItems)
+
+          // check if the grid is full
+          if (gridItems.length >= 12) {
+            // show a modal to the user that the grid is full
+            setStep('selectItemToReplace')
+          } else {
+            addToProfile(itemToAdd.expand.ref, true, {
+              backlog: false,
+              comment: itemToAdd.text,
+            }).then(() => {
+              setStep('addedToGrid')
+            })
+          }
+        }
       }
     }
-    fetchGridItems()
-  }, [user])
+    initialize()
+  }, [itemToAdd])
 
   // const [addingTo, setAddingTo] = useState<'backlog' | 'grid' | null>(null)
   const [step, setStep] = useState<
-    | 'chooseTarget'
-    | 'selectItemToReplace'
-    | 'addedToBacklog'
-    | 'addedToGrid'
-    | 'chooseReplaceItemMethod'
-  >('chooseTarget')
+    null | 'selectItemToReplace' | 'addedToBacklog' | 'addedToGrid' | 'chooseReplaceItemMethod'
+  >(null)
   const [itemToReplace, setItemToReplace] = useState<ExpandedItem | null>(null)
 
   const sheetHeight =
@@ -78,7 +87,7 @@ export const AddRefSheet = ({
       onChange={(i: number) => {
         if (i === -1) {
           setItemToReplace(null)
-          setStep('chooseTarget')
+          setStep(null)
         }
       }}
       backdropComponent={(p) => (
@@ -114,43 +123,6 @@ export const AddRefSheet = ({
       )}
       keyboardBehavior="interactive"
     >
-      {step === 'chooseTarget' && (
-        <View style={{ display: 'flex', flexDirection: 'column', padding: s.$3, gap: s.$1 }}>
-          <Button
-            title="Add to backlog"
-            onPress={async () => {
-              if (!itemToAdd?.expand.ref) return
-              // add the item to the backlog
-              await addToProfile(itemToAdd.expand.ref, true, {
-                backlog: true,
-                comment: itemToAdd.text,
-              })
-              setStep('addedToBacklog')
-            }}
-            variant="basic"
-            style={{ backgroundColor: c.surface2 }}
-            textStyle={{ color: c.muted2 }}
-          />
-          <Button
-            title="Add to grid"
-            onPress={async () => {
-              if (!itemToAdd) return
-              // check if the grid is full
-              if (gridItems.length >= 12) {
-                // show a modal to the user that the grid is full
-                setStep('selectItemToReplace')
-              } else {
-                await addToProfile(itemToAdd.expand.ref, true, {
-                  backlog: false,
-                  comment: itemToAdd.text,
-                })
-                setStep('addedToGrid')
-              }
-            }}
-            variant="raised"
-          />
-        </View>
-      )}
       {step === 'selectItemToReplace' && (
         <View
           style={{

--- a/ui/profiles/sheets/AddRefSheet.tsx
+++ b/ui/profiles/sheets/AddRefSheet.tsx
@@ -51,7 +51,7 @@ export const AddRefSheet = ({
           } else {
             addToProfile(itemToAdd.expand.ref, true, {
               backlog: false,
-              comment: itemToAdd.text,
+              text: itemToAdd.text,
             }).then(() => {
               setStep('addedToGrid')
             })
@@ -163,7 +163,7 @@ export const AddRefSheet = ({
               if (!itemToAdd) return
               await addToProfile(itemToAdd.expand.ref, true, {
                 backlog: true,
-                comment: itemToAdd.text,
+                text: itemToAdd.text,
               })
               setStep('addedToBacklog')
             }}
@@ -205,7 +205,7 @@ export const AddRefSheet = ({
               await removeFromProfile(itemToReplace.id)
               await addToProfile(itemToAdd.expand.ref, true, {
                 backlog: false,
-                comment: itemToAdd.text,
+                text: itemToAdd.text,
               })
               setStep('addedToGrid')
             }}
@@ -219,7 +219,7 @@ export const AddRefSheet = ({
               // replace the item
               await addToProfile(itemToAdd.expand.ref, true, {
                 backlog: false,
-                comment: itemToAdd.text,
+                text: itemToAdd.text,
               })
               setStep('addedToGrid')
             }}

--- a/ui/profiles/sheets/AddRefSheet.tsx
+++ b/ui/profiles/sheets/AddRefSheet.tsx
@@ -49,12 +49,11 @@ export const AddRefSheet = ({
             // show a modal to the user that the grid is full
             setStep('selectItemToReplace')
           } else {
-            addToProfile(itemToAdd.expand.ref, true, {
+            await addToProfile(itemToAdd.expand.ref, {
               backlog: false,
               text: itemToAdd.text,
-            }).then(() => {
-              setStep('addedToGrid')
             })
+            setStep('addedToGrid')
           }
         }
       }
@@ -161,7 +160,7 @@ export const AddRefSheet = ({
             variant="small"
             onPress={async () => {
               if (!itemToAdd) return
-              await addToProfile(itemToAdd.expand.ref, true, {
+              await addToProfile(itemToAdd.expand.ref, {
                 backlog: true,
                 text: itemToAdd.text,
               })
@@ -203,7 +202,7 @@ export const AddRefSheet = ({
               if (!itemToAdd?.expand.ref) return
               // remove the item
               await removeFromProfile(itemToReplace.id)
-              await addToProfile(itemToAdd.expand.ref, true, {
+              await addToProfile(itemToAdd.expand.ref, {
                 backlog: false,
                 text: itemToAdd.text,
               })
@@ -217,7 +216,7 @@ export const AddRefSheet = ({
               // send itemToReplace to the backlog
               await moveToBacklog(itemToReplace.id)
               // replace the item
-              await addToProfile(itemToAdd.expand.ref, true, {
+              await addToProfile(itemToAdd.expand.ref, {
                 backlog: false,
                 text: itemToAdd.text,
               })

--- a/ui/profiles/sheets/AddRefSheet.tsx
+++ b/ui/profiles/sheets/AddRefSheet.tsx
@@ -83,7 +83,7 @@ export const AddRefSheet = ({
       snapPoints={[sheetHeight]}
       index={-1}
       animatedIndex={addRefSheetBackdropAnimatedIndex}
-      backgroundStyle={{ backgroundColor: c.surface, borderRadius: s.$4, paddingTop: 0 }}
+      backgroundStyle={{ backgroundColor: c.olive, borderRadius: s.$4, paddingTop: 0 }}
       onChange={(i: number) => {
         if (i === -1) {
           setItemToReplace(null)
@@ -133,20 +133,22 @@ export const AddRefSheet = ({
             alignItems: 'center',
           }}
         >
-          <Text>Adding {itemToAdd?.expand.ref.title} to your profile</Text>
+          <Text style={{ color: c.surface, fontSize: s.$1 }}>
+            Adding {itemToAdd?.expand.ref.title} to your profile
+          </Text>
           {itemToAdd?.expand.ref?.image && (
             <View style={{ alignItems: 'center' }}>
               <SimplePinataImage
                 originalSource={itemToAdd.expand.ref?.image}
-                style={{ height: 100, width: 100 }}
+                style={{ height: 80, width: 80 }}
                 imageOptions={{
-                  width: 100,
-                  height: 100,
+                  width: 80,
+                  height: 80,
                 }}
               />
             </View>
           )}
-          <Text>Choose a grid item to replace</Text>
+          <Text style={{ color: c.surface, fontSize: s.$1 }}>Choose a grid item to replace</Text>
           <AddRefSheetGrid
             gridItems={gridItems}
             onSelectItem={(item) => {
@@ -156,7 +158,7 @@ export const AddRefSheet = ({
           />
           <Button
             title="Add to backlog instead"
-            variant="smallMuted"
+            variant="small"
             onPress={async () => {
               if (!itemToAdd) return
               await addToProfile(itemToAdd.expand.ref, true, {
@@ -226,12 +228,16 @@ export const AddRefSheet = ({
       )}
       {step === 'addedToBacklog' && (
         <View style={{ padding: s.$3 }}>
-          <Heading tag="h1">{itemToAdd?.expand.ref.title} was added to the backlog</Heading>
+          <Heading tag="h1" style={{ color: c.surface }}>
+            {itemToAdd?.expand.ref.title} was added to the backlog
+          </Heading>
         </View>
       )}
       {step === 'addedToGrid' && (
         <View style={{ padding: s.$3 }}>
-          <Heading tag="h1">{itemToAdd?.expand.ref.title} was added to grid</Heading>
+          <Heading tag="h1" style={{ color: c.surface }}>
+            {itemToAdd?.expand.ref.title} was added to grid
+          </Heading>
         </View>
       )}
     </BottomSheet>

--- a/ui/profiles/sheets/AddRefSheet.tsx
+++ b/ui/profiles/sheets/AddRefSheet.tsx
@@ -119,6 +119,7 @@ export const AddRefSheet = ({
         <View style={{ padding: s.$3 }}>
           <RefForm
             r={refData}
+            canEditRefData={false}
             onAddRefToList={async (fields) => {
               console.log('TODO: onAddRefToList')
             }}

--- a/ui/profiles/sheets/AddRefSheet.tsx
+++ b/ui/profiles/sheets/AddRefSheet.tsx
@@ -69,7 +69,7 @@ export const AddRefSheet = ({
   const [itemToReplace, setItemToReplace] = useState<ExpandedItem | null>(null)
 
   const sheetHeight =
-    step === 'selectItemToReplace' ? '80%' : step === 'chooseReplaceItemMethod' ? '50%' : '30%'
+    step === 'selectItemToReplace' ? '90%' : step === 'chooseReplaceItemMethod' ? '50%' : '30%'
 
   const disappearsOnIndex = -1
   const appearsOnIndex = 0
@@ -133,6 +133,19 @@ export const AddRefSheet = ({
             alignItems: 'center',
           }}
         >
+          <Text>Adding {itemToAdd?.expand.ref.title} to your profile</Text>
+          {itemToAdd?.expand.ref?.image && (
+            <View style={{ alignItems: 'center' }}>
+              <SimplePinataImage
+                originalSource={itemToAdd.expand.ref?.image}
+                style={{ height: 100, width: 100 }}
+                imageOptions={{
+                  width: 100,
+                  height: 100,
+                }}
+              />
+            </View>
+          )}
           <Text>Choose a grid item to replace</Text>
           <AddRefSheetGrid
             gridItems={gridItems}


### PR DESCRIPTION
#240

When we click the "Add Ref +" button, open the "new ref" form so that the user can provide their own image/description/url (but not title). Then proceed with the same add ref flow as usual.
