### PR TITLE
Move meatball menu to be next to link

### DIFF
--- a/features/pocketbase/stores/items.ts
+++ b/features/pocketbase/stores/items.ts
@@ -164,7 +164,7 @@ export const getProfileItems = async (userName: string) => {
         userName,
       }
     ),
-    expand: 'items_via_parent, ref, items_via_parent.ref',
+    expand: 'items_via_parent, ref, items_via_parent.ref, creator',
   })
   return gridSort(items)
 }

--- a/features/user/detail-screen.tsx
+++ b/features/user/detail-screen.tsx
@@ -45,8 +45,9 @@ export function UserDetailsScreen({
         editingRights={editingRights}
         initialIndex={initialIndex}
         openedFromFeed={openedFromFeed}
+        profile={profile}
       >
-        <Details profile={profile} data={items} />
+        <Details data={items} />
       </ProfileDetailsProvider>
     )
   } else {

--- a/ui/profiles/Details.tsx
+++ b/ui/profiles/Details.tsx
@@ -1,22 +1,17 @@
 import { useItemStore } from '@/features/pocketbase/stores/items'
 import { ItemsRecord } from '@/features/pocketbase/stores/pocketbase-types'
-import { ExpandedItem, ExpandedProfile } from '@/features/pocketbase/stores/types'
-import { c, s } from '@/features/style'
-import { XStack } from '@/ui/core/Stacks'
+import { ExpandedItem } from '@/features/pocketbase/stores/types'
+import { c } from '@/features/style'
 import { useUIStore } from '@/ui/state'
-import { useRouter } from 'expo-router'
-import React, { useCallback, useContext, useRef, useState } from 'react'
-import { Pressable, Text, useWindowDimensions, View } from 'react-native'
+import React, { useCallback, useContext, useRef } from 'react'
+import { useWindowDimensions } from 'react-native'
 import Carousel, { ICarouselInstance } from 'react-native-reanimated-carousel'
 import { useStore } from 'zustand'
-import { Avatar } from '../atoms/Avatar'
-import { Checkbox, MeatballMenu } from '../atoms/MeatballMenu'
 import { Sheet } from '../core/Sheets'
 import { GridLines } from '../display/Gridlines'
 import { EditableList } from '../lists/EditableList'
 import { DetailsCarouselItem } from './DetailsCarouselItem'
 import { ProfileDetailsContext } from './profileDetailsStore'
-import BottomSheet from '@gorhom/bottom-sheet'
 
 // --- Helper Components for State Isolation ---
 
@@ -29,75 +24,16 @@ const ConditionalGridLines = React.memo(() => {
 })
 ConditionalGridLines.displayName = 'ConditionalGridLines'
 
-const DetailsHeaderButton = () => {
-  const profileDetailsStore = useContext(ProfileDetailsContext)
-  const showContextMenu = useStore(profileDetailsStore, (state) => state.showContextMenu)
-  const setShowContextMenu = useStore(profileDetailsStore, (state) => state.setShowContextMenu)
-
-  return (
-    <MeatballMenu
-      onPress={() => {
-        setShowContextMenu(!showContextMenu)
-      }}
-    />
-  )
-}
-DetailsHeaderButton.displayName = 'DetailsHeaderButton'
-
-const ApplyChangesButton = () => {
-  const update = useItemStore((state) => state.update)
-  const stopEditing = useItemStore((state) => state.stopEditing)
-  const triggerProfileRefresh = useItemStore((state) => state.triggerProfileRefresh)
-
-  return (
-    <Checkbox
-      onPress={async () => {
-        await update()
-        stopEditing()
-        triggerProfileRefresh()
-      }}
-    />
-  )
-}
-ApplyChangesButton.displayName = 'ApplyChangesButton'
-
-const ProfileLabel = ({ profile }: { profile: ExpandedProfile }) => {
-  const router = useRouter()
-  return (
-    <Pressable
-      onPress={() => {
-        router.replace(`/user/${profile.userName}`)
-      }}
-    >
-      <XStack style={{ alignItems: 'center' }} gap={s.$075}>
-        {/* show user avatar and name */}
-        <Text style={{ fontSize: s.$1, fontWeight: 500, opacity: 0.6, color: c.muted }}>
-          {profile.firstName}
-        </Text>
-        <Avatar size={s.$1} source={profile.image} />
-      </XStack>
-    </Pressable>
-  )
-}
-ProfileLabel.displayName = 'ProfileLabel'
-
 // --- Main Components ---
 
-export const Details = ({ profile, data }: { profile: ExpandedProfile; data: ItemsRecord[] }) => {
-  const router = useRouter()
+export const Details = ({ data }: { data: ItemsRecord[] }) => {
   const ref = useRef<ICarouselInstance>(null)
-  const addRefSheetRef = useRef<BottomSheet>(null)
   const win = useWindowDimensions()
-
-  const [itemToAdd, setItemToAdd] = useState<ExpandedItem | null>(null)
 
   const profileDetailsStore = useContext(ProfileDetailsContext)
   const setShowContextMenu = useStore(profileDetailsStore, (state) => state.setShowContextMenu)
   const setCurrentIndex = useStore(profileDetailsStore, (state) => state.setCurrentIndex)
   const currentIndex = useStore(profileDetailsStore, (state) => state.currentIndex)
-  const openedFromFeed = useStore(profileDetailsStore, (state) => state.openedFromFeed)
-
-  const editing = useItemStore((state) => state.editing)
 
   const { addingToList, setAddingToList, addingItem } = useUIStore()
   const { stopEditing, update } = useItemStore()
@@ -118,31 +54,6 @@ export const Details = ({ profile, data }: { profile: ExpandedProfile; data: Ite
     <>
       <ConditionalGridLines />
 
-      {openedFromFeed ? (
-        <>
-          <View style={{ paddingLeft: s.$3, paddingTop: s.$2, paddingBottom: s.$05 }}>
-            <ProfileLabel profile={profile} />
-          </View>
-          <View style={{ position: 'absolute', right: s.$3, top: s.$2, zIndex: 99 }}>
-            {editing && <ApplyChangesButton />}
-          </View>
-        </>
-      ) : (
-        <View
-          style={{
-            paddingLeft: s.$3,
-            paddingRight: s.$3,
-            paddingTop: s.$6,
-            paddingBottom: s.$1,
-            display: 'flex',
-            flexDirection: 'row',
-            justifyContent: 'flex-end',
-          }}
-        >
-          {editing ? <ApplyChangesButton /> : <DetailsHeaderButton />}
-        </View>
-      )}
-
       <Carousel
         loop={data.length > 1}
         ref={ref}
@@ -162,7 +73,7 @@ export const Details = ({ profile, data }: { profile: ExpandedProfile; data: Ite
           setShowContextMenu(false)
         }}
         onConfigurePanGesture={handleConfigurePanGesture}
-        renderItem={DetailsCarouselItem}
+        renderItem={({ item, index }) => <DetailsCarouselItem item={item} index={index} />}
         windowSize={5}
         pagingEnabled={true}
         snapEnabled={true}

--- a/ui/profiles/DetailsCarouselItem.tsx
+++ b/ui/profiles/DetailsCarouselItem.tsx
@@ -1,6 +1,6 @@
 import { useItemStore, useUserStore } from '@/features/pocketbase'
-import { RefsRecord } from '@/features/pocketbase/stores/pocketbase-types'
-import { ExpandedItem, ExpandedProfile } from '@/features/pocketbase/stores/types'
+import { RefsRecord, UsersRecord } from '@/features/pocketbase/stores/pocketbase-types'
+import { ExpandedItem } from '@/features/pocketbase/stores/types'
 import { base, c, s, t } from '@/features/style'
 import { SearchRef } from '@/ui/actions/SearchRef'
 import { Avatar } from '@/ui/atoms/Avatar'
@@ -85,7 +85,7 @@ const ApplyChangesButton = () => {
 }
 ApplyChangesButton.displayName = 'ApplyChangesButton'
 
-const ProfileLabel = ({ profile }: { profile: ExpandedProfile }) => {
+const ProfileLabel = ({ profile }: { profile: UsersRecord }) => {
   const router = useRouter()
   return (
     <Pressable
@@ -109,14 +109,8 @@ export const DetailsCarouselItem = ({ item, index }: { item: ExpandedItem; index
   const win = useWindowDimensions()
 
   const profileDetailsStore = useContext(ProfileDetailsContext)
-  const {
-    currentIndex,
-    showContextMenu,
-    setShowContextMenu,
-    openedFromFeed,
-    editingRights,
-    profile,
-  } = useStore(profileDetailsStore)
+  const { currentIndex, showContextMenu, setShowContextMenu, openedFromFeed, editingRights } =
+    useStore(profileDetailsStore)
   const [currentItem, setCurrentItem] = useState<ExpandedItem>(item)
   const { addRefSheetRef, setAddingRefId } = useUIStore()
 
@@ -165,7 +159,7 @@ export const DetailsCarouselItem = ({ item, index }: { item: ExpandedItem; index
           keyboardVerticalOffset={openedFromFeed ? 70 : 120}
         >
           <View style={{ paddingLeft: s.$3, paddingTop: s.$1, paddingBottom: s.$05 }}>
-            {openedFromFeed && <ProfileLabel profile={profile} />}
+            {openedFromFeed && <ProfileLabel profile={item.expand.creator} />}
           </View>
           <View style={{ position: 'absolute', right: s.$3, top: s.$2, zIndex: 99 }}>
             {editing && <ApplyChangesButton />}

--- a/ui/profiles/DetailsCarouselItem.tsx
+++ b/ui/profiles/DetailsCarouselItem.tsx
@@ -148,7 +148,7 @@ export const DetailsCarouselItem = ({ item, index }: { item: ExpandedItem; index
     <View
       style={{
         width: win.width,
-        height: openedFromFeed ? win.height * 0.8 : win.height * 0.8 - s.$7,
+        height: win.height * 0.8,
         gap: s.$1,
         justifyContent: 'flex-start',
       }}

--- a/ui/profiles/ProfileDetailsSheet.tsx
+++ b/ui/profiles/ProfileDetailsSheet.tsx
@@ -89,8 +89,9 @@ export const ProfileDetailsSheet = ({
           editingRights={editingRights}
           initialIndex={initialIndex}
           openedFromFeed={openedFromFeed}
+          profile={profile}
         >
-          <Details profile={profile} data={gridItems} />
+          <Details data={gridItems} />
         </ProfileDetailsProvider>
       )}
     </BottomSheet>

--- a/ui/profiles/ProfileDetailsSheet.tsx
+++ b/ui/profiles/ProfileDetailsSheet.tsx
@@ -89,7 +89,6 @@ export const ProfileDetailsSheet = ({
           editingRights={editingRights}
           initialIndex={initialIndex}
           openedFromFeed={openedFromFeed}
-          profile={profile}
         >
           <Details data={gridItems} />
         </ProfileDetailsProvider>

--- a/ui/profiles/profileDetailsStore.tsx
+++ b/ui/profiles/profileDetailsStore.tsx
@@ -1,3 +1,4 @@
+import { ExpandedProfile } from '@/features/pocketbase/stores/types'
 import { createContext, ReactNode, useState } from 'react'
 import { createStore, StoreApi } from 'zustand'
 
@@ -10,6 +11,7 @@ type ProfileDetailsState = {
   setIsEditing: (newValue: boolean) => void
   openedFromFeed: boolean
   editingRights: boolean
+  profile: ExpandedProfile
 }
 
 // define a "profile store"
@@ -23,11 +25,13 @@ export const ProfileDetailsProvider = ({
   initialIndex,
   openedFromFeed,
   editingRights,
+  profile,
 }: {
   children: ReactNode
   initialIndex: number
   openedFromFeed: boolean
   editingRights: boolean
+  profile: ExpandedProfile
 }) => {
   const [profileDetailsStore] = useState(() =>
     createStore<ProfileDetailsState>((set) => ({
@@ -37,6 +41,7 @@ export const ProfileDetailsProvider = ({
       setShowContextMenu: (newShowContextMenu) => set({ showContextMenu: newShowContextMenu }),
       isEditing: false,
       setIsEditing: (newIsEditing) => set({ isEditing: newIsEditing }),
+      profile,
       openedFromFeed,
       editingRights,
     }))

--- a/ui/profiles/profileDetailsStore.tsx
+++ b/ui/profiles/profileDetailsStore.tsx
@@ -11,7 +11,6 @@ type ProfileDetailsState = {
   setIsEditing: (newValue: boolean) => void
   openedFromFeed: boolean
   editingRights: boolean
-  profile: ExpandedProfile
 }
 
 // define a "profile store"
@@ -25,13 +24,11 @@ export const ProfileDetailsProvider = ({
   initialIndex,
   openedFromFeed,
   editingRights,
-  profile,
 }: {
   children: ReactNode
   initialIndex: number
   openedFromFeed: boolean
   editingRights: boolean
-  profile: ExpandedProfile
 }) => {
   const [profileDetailsStore] = useState(() =>
     createStore<ProfileDetailsState>((set) => ({
@@ -41,7 +38,6 @@ export const ProfileDetailsProvider = ({
       setShowContextMenu: (newShowContextMenu) => set({ showContextMenu: newShowContextMenu }),
       isEditing: false,
       setIsEditing: (newIsEditing) => set({ isEditing: newIsEditing }),
-      profile,
       openedFromFeed,
       editingRights,
     }))


### PR DESCRIPTION
Fixes #252

This PR moves the meatball menu to be next to the link/title in the details carousel.

![simulator_screenshot_50E75CB1-B1CB-428A-9E48-DF03EA71567D](https://github.com/user-attachments/assets/43fcc7b8-fac6-4367-bab9-7137454a2d75)
![simulator_screenshot_8BCEC29F-66DA-4C4F-9D3E-2FA794CC1B3B](https://github.com/user-attachments/assets/fd74da02-7a0e-4c1b-a142-c045bc431862)
