### PR TITLE
remove console.log statements

### DIFF
--- a/app/+native-intent.tsx
+++ b/app/+native-intent.tsx
@@ -8,12 +8,7 @@ export function redirectSystemPath({ path, initial }: { path: string; initial: s
     if (path.includes(`dataUrl=${getShareExtensionKey()}`)) {
       console.debug('[expo-router-native-intent] redirect to ShareIntent screen')
 
-      console.log(!pocketbase.authStore.isValid || !pocketbase.authStore.record?.userName)
-      console.log(!pocketbase.authStore.isValid, !pocketbase.authStore.record?.userName)
-
       if (!pocketbase.authStore.isValid) returnValue = '/login'
-
-      console.log(`/user/${pocketbase?.authStore?.record?.userName}`)
 
       returnValue = `/user/${pocketbase?.authStore?.record?.userName}`
     } else {
@@ -22,8 +17,6 @@ export function redirectSystemPath({ path, initial }: { path: string; initial: s
   } catch {
     returnValue = '/'
   }
-
-  console.log(returnValue)
 
   return returnValue
 }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -93,13 +93,6 @@ export default function RootLayout() {
   useEffect(() => {
     // Initialize user store to sync with PocketBase auth
     init()
-
-    const unsubscribe = NetInfo.addEventListener((state) => {
-      console.log('Connection type', state.type)
-      console.log('Is connected?', state.isConnected)
-    })
-
-    return unsubscribe
   }, [init])
 
   return (

--- a/app/user/login.tsx
+++ b/app/user/login.tsx
@@ -34,7 +34,7 @@ const EmailStep = ({ carouselRef }: { carouselRef: React.RefObject<ICarouselInst
           // Valid?
           carouselRef.current?.next()
         },
-        (errors) => console.log('Errors:', errors)
+        (errors) => {}
       )}
       disabled={!isValid}
     >

--- a/features/home/screen.tsx
+++ b/features/home/screen.tsx
@@ -1,7 +1,7 @@
 import { View, Dimensions, DimensionValue } from 'react-native'
 import { useEffect } from 'react'
 import { Button, YStack, Heading } from '../../ui/index'
-import { pocketbase, useUserStore } from '@/features/pocketbase'
+import { useUserStore } from '@/features/pocketbase'
 import Animated, {
   useAnimatedStyle,
   Easing,
@@ -12,7 +12,6 @@ import Animated, {
 
 import { router } from 'expo-router'
 import { c, s } from '@/features/style/index'
-import { UserProfileScreen } from '../user/profile-screen'
 import { Feed } from './feed'
 
 const dims = Dimensions.get('window')
@@ -63,11 +62,6 @@ function RotatingImage() {
 
 export function HomeScreen() {
   const { user } = useUserStore()
-
-  useEffect(() => {
-    console.log('USER ON HOMESCREEN', user?.userName)
-    console.log('Pocketbase auth store', pocketbase.authStore.isValid)
-  }, [user, pocketbase])
 
   if (user) {
     // if the user is logged in, show the user's profile

--- a/features/messaging/message-loader.tsx
+++ b/features/messaging/message-loader.tsx
@@ -93,7 +93,6 @@ export function MessagesInit() {
   useEffect(() => {
     if (!user) return
     try {
-      console.log(`subscribing to new messages, user: ${user?.userName}`)
       pocketbase.collection('messages').subscribe<Message>('*', (e) => {
         if (e.action === 'create') {
           addNewMessage(e.record.conversation!, e.record)
@@ -104,7 +103,6 @@ export function MessagesInit() {
     }
 
     return () => {
-      console.log('unsubscribe from messages')
       pocketbase.collection('messages').unsubscribe('*')
     }
   }, [user])
@@ -113,7 +111,6 @@ export function MessagesInit() {
   useEffect(() => {
     if (!user) return
     try {
-      console.log(`subscribing to new reactions, user: ${user?.userName}`)
       pocketbase.collection('reactions').subscribe<Reaction>('*', async (e) => {
         if (e.action === 'create') {
           const expandedReaction = await pocketbase
@@ -130,7 +127,6 @@ export function MessagesInit() {
     }
 
     return () => {
-      console.log('unsubscribe from reactions')
       pocketbase.collection('reactions').unsubscribe('*')
     }
   }, [user])
@@ -138,7 +134,6 @@ export function MessagesInit() {
   //subscribe to membership updates (to see new conversations)
   useEffect(() => {
     if (!user) return
-    console.log(`subscribing to memberships, user: ${user?.userName}`)
     try {
       pocketbase.collection('memberships').subscribe('*', async (e) => {
         if (e.action === 'update') {
@@ -170,7 +165,6 @@ export function MessagesInit() {
       console.error(error)
     }
     return () => {
-      console.log('unsubscribe from memberships')
       pocketbase.collection('memberships').unsubscribe('*')
     }
   }, [user])

--- a/features/messaging/messages-screen.tsx
+++ b/features/messaging/messages-screen.tsx
@@ -217,11 +217,7 @@ export function MessagesScreen({ conversationId }: { conversationId: string }) {
             }}
             style={{ padding: s.$2 }}
           >
-            <AvatarPicker
-              source={''}
-              onComplete={(s) => setImageUrl(s)}
-              onReplace={() => console.log('replace')}
-            >
+            <AvatarPicker source={''} onComplete={(s) => setImageUrl(s)} onReplace={() => {}}>
               {null}
             </AvatarPicker>
           </Sheet>

--- a/features/pinata/index.ts
+++ b/features/pinata/index.ts
@@ -57,15 +57,8 @@ export const pinataUpload = async (
   asset: ImagePicker.ImagePickerAsset,
   config: { prefix?: string } = { prefix: 'refs' }
 ): Promise<string> => {
-  const startTime = Date.now()
-  console.log('🚀 Starting Pinata upload with asset:', asset)
-  console.log('📝 Upload config:', config)
-  console.log('⏱️ Upload started at:', new Date(startTime).toISOString())
-
   const form = new FormData()
   const fileName = `${config.prefix}-${Date.now()}`
-
-  console.log('📂 Generated filename:', fileName)
 
   form.append('name', fileName)
   // TODO: uri isn't supposed to be on Blob?
@@ -92,19 +85,8 @@ export const pinataUpload = async (
     const unsignedUrl = `https://violet-fashionable-blackbird-836.mypinata.cloud/files/${result.data.cid}`
     const { signedUrl } = await pinataSignedUrl(unsignedUrl)
 
-    const endTime = Date.now()
-    const duration = endTime - startTime
-    console.log('✅ Upload completed at:', new Date(endTime).toISOString())
-    console.log('🕐 Total upload duration:', `${duration}ms`)
-    console.log('🔗 Generated signed URL:', signedUrl)
-    console.log('📁 File CID:', result.data.cid)
-
     return signedUrl
   } catch (error) {
-    const endTime = Date.now()
-    const duration = endTime - startTime
-    console.log('❌ Upload failed at:', new Date(endTime).toISOString())
-    console.log('🕐 Failed after:', `${duration}ms`)
     console.error(error)
     throw error
   }

--- a/features/pocketbase/index.tsx
+++ b/features/pocketbase/index.tsx
@@ -2,15 +2,12 @@ import { pocketbase } from './pocketbase'
 import { useUserStore } from './stores/users'
 import { useRefStore } from './stores/refs'
 import { useItemStore } from './stores/items'
-import { StagedRef, CompleteRef, Item, ExpandedItem } from './stores/types'
+import { StagedRef, CompleteRef, ExpandedItem } from './stores/types'
 
 const addToProfile: (
   stagedRef: StagedRef | CompleteRef,
   options: { image?: string; text?: string; backlog?: boolean; list?: boolean }
 ) => Promise<ExpandedItem> = async (stagedRef, options = {}) => {
-  console.log('WE GOT STAGED', 'list' in stagedRef ? stagedRef.list : null)
-  console.log('WE GOT OPTIONS', options.list)
-
   const refStore = useRefStore.getState()
   const itemStore = useItemStore.getState()
 

--- a/features/pocketbase/pocketbase.ts
+++ b/features/pocketbase/pocketbase.ts
@@ -11,8 +11,6 @@ const store = new AsyncAuthStore({
   initial: AsyncStorage.getItem('pb_auth'),
 })
 
-console.log('creating new pocketbase at ', process.env.EXPO_PUBLIC_POCKETBASE_URL)
-
 const pocketbase = new PocketBase(process.env.EXPO_PUBLIC_POCKETBASE_URL, store)
 
 pocketbase.autoCancellation(false)

--- a/features/pocketbase/stores/items.ts
+++ b/features/pocketbase/stores/items.ts
@@ -76,7 +76,6 @@ export const useItemStore = create<{
   triggerProfileRefresh: () =>
     set((state) => ({ profileRefreshTrigger: state.profileRefreshTrigger + 1 })),
   push: async (newItem: StagedItem) => {
-    console.log('ITEMS PUSH')
     try {
       const record = await pocketbase
         .collection('items')
@@ -87,8 +86,6 @@ export const useItemStore = create<{
         const newItems = [...state.items, record]
         return { items: newItems, feedRefreshTrigger: state.feedRefreshTrigger + 1 }
       })
-
-      console.log('PUSHED ItEM', record)
 
       return record
     } catch (error) {

--- a/features/pocketbase/stores/users.ts
+++ b/features/pocketbase/stores/users.ts
@@ -93,9 +93,6 @@ export const useUserStore = create<{
         .collection<UsersRecord>('users')
         .update(pocketbase.authStore.record.id, { ...fields })
 
-      console.log('Updated user', fields)
-      console.log(record)
-
       await canvasApp.actions.updateUser(pocketbase.authStore.record.id, fields)
 
       return record

--- a/ui/actions/NewRef.tsx
+++ b/ui/actions/NewRef.tsx
@@ -32,7 +32,7 @@ export const NewRef = ({
   initialStep = 'search',
   initialRefData = {},
   onNewRef,
-  onStep = (s) => console.log(s),
+  onStep = () => {},
   onCancel,
   backlog = false,
 }: {
@@ -66,7 +66,6 @@ export const NewRef = ({
   }
 
   const addRefFromResults = (newRef: StagedRef) => {
-    console.log(newRef)
     setRefData(newRef)
     setStep('add')
   }

--- a/ui/actions/RefForm.tsx
+++ b/ui/actions/RefForm.tsx
@@ -93,7 +93,6 @@ export const RefForm = ({
     // Set pinataSource immediately to update UI
     setPinataSource(imageUrl)
 
-    console.log('image success')
     // Prefetch image in background as optimization, but don't block UI updates
     Image.prefetch(imageUrl).catch((err) => {
       console.error('Failed to prefetch image:', err)
@@ -438,12 +437,10 @@ export const RefForm = ({
               try {
                 setCreateInProgress(true)
                 await onAddRefToList({ title, text, url, image: pinataSource, meta })
-                console.log('success')
               } catch (e) {
                 console.error(e)
               } finally {
                 setCreateInProgress(false)
-                console.log('Done')
               }
             }}
           />
@@ -487,12 +484,10 @@ export const RefForm = ({
                 try {
                   setCreateInProgress(true)
                   await onAddRef({ title, text, url, image: pinataSource, meta })
-                  console.log('success')
                 } catch (e) {
                   console.error(e)
                 } finally {
                   setCreateInProgress(false)
-                  console.log('Done')
                 }
               }}
             />

--- a/ui/actions/SearchBottomSheet.tsx
+++ b/ui/actions/SearchBottomSheet.tsx
@@ -160,7 +160,6 @@ export default function SearchBottomSheet() {
             backlog={addingTo === 'backlog'}
             onStep={(step) => {
               setStep(step)
-              console.log('step is', step)
               if (step === 'add' && snapPoints.length > 2) searchSheetRef.current?.snapToIndex(2)
             }}
             onNewRef={async (itm: Item) => {

--- a/ui/actions/SearchRef.tsx
+++ b/ui/actions/SearchRef.tsx
@@ -202,7 +202,6 @@ export const SearchRef = ({
 
     // otherwise, search for images
     try {
-      console.log('searching for images')
       const params = new URLSearchParams({
         key: process.env.EXPO_PUBLIC_GOOGLE_SEARCH_API_KEY!,
         cx: process.env.EXPO_PUBLIC_GOOGLE_SEARCH_ENGINE_ID!,
@@ -296,7 +295,6 @@ export const SearchRef = ({
         {picking && (
           <Picker
             onSuccess={(a: ImagePickerAsset) => {
-              console.log('image asset', a)
               setImageAsset(a)
               setPicking(false)
               setUploadInProgress(true)

--- a/ui/atoms/EditableHeader.tsx
+++ b/ui/atoms/EditableHeader.tsx
@@ -37,12 +37,10 @@ export const EditableHeader = ({
     // pass the link directly
     getLinkPreview(u).then((data) => {
       if ('title' in data && data?.title && title === '') {
-        console.log('SETTING TITLE: ', data.title)
         setTitle(data.title)
       }
 
       if ('images' in data && data?.images?.length > 0 && !image) {
-        console.log('IMAGE', data.images[0])
         setImage(data.images[0])
       }
     })

--- a/ui/atoms/ExpandButtonList.tsx
+++ b/ui/atoms/ExpandButtonList.tsx
@@ -82,9 +82,7 @@ export const ExpandButton = ({
     }
   }
 
-  const onItemPress = (o: ExpandOption, i: number) => {
-    console.log(o.label)
-  }
+  const onItemPress = (o: ExpandOption, i: number) => {}
 
   return (
     <View

--- a/ui/atoms/Shareable.tsx
+++ b/ui/atoms/Shareable.tsx
@@ -14,7 +14,6 @@ export const Shareable = ({
   onShare?: () => void
 }) => {
   const onShareFn = async () => {
-    console.log('share')
     message += ` ${url}`
     try {
       const result = await Share.share({ message, url })

--- a/ui/atoms/TypewriterText.tsx
+++ b/ui/atoms/TypewriterText.tsx
@@ -17,7 +17,6 @@ export const TypewriterText = ({
   const [displayedText, setDisplayedText] = useState(text)
 
   useEffect(() => {
-    console.log(text, 'from typewriter')
     let cancelled = false
 
     const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))

--- a/ui/core/Sheets.tsx
+++ b/ui/core/Sheets.tsx
@@ -23,7 +23,6 @@ export const Sheet = (props: any = { full: false, noNotch: false, noPadding: fal
   }, [win.height, insets.top, keyboard.height])
 
   const snapPoints = useDerivedValue(() => {
-    console.log(maxSnapPoint)
     return [maxSnapPoint.value]
   }, [maxSnapPoint])
 

--- a/ui/display/DetailsDemo.tsx
+++ b/ui/display/DetailsDemo.tsx
@@ -5,19 +5,27 @@ import Carousel, { CarouselRenderItem, ICarouselInstance } from 'react-native-re
 
 export const DetailsDemoCarousel = forwardRef(
   (
-    { data, height, width, defaultIndex, style, scrollOffsetValue, onSnapToItem, renderItem }: {
-      data: unknown[],
-      height: number,
-      width: number,
-      defaultIndex: number,
-      style: StyleProp<ViewStyle>,
-      scrollOffsetValue: SharedValue<number>,
-      onSnapToItem?: ((index: number) => void),
-      renderItem: CarouselRenderItem<unknown>,
+    {
+      data,
+      height,
+      width,
+      defaultIndex,
+      style,
+      scrollOffsetValue,
+      onSnapToItem,
+      renderItem,
+    }: {
+      data: unknown[]
+      height: number
+      width: number
+      defaultIndex: number
+      style: StyleProp<ViewStyle>
+      scrollOffsetValue: SharedValue<number>
+      onSnapToItem?: (index: number) => void
+      renderItem: CarouselRenderItem<unknown>
     },
     ref
   ) => {
-    console.log(style)
     return (
       <Carousel
         onConfigurePanGesture={(gesture) => {

--- a/ui/display/Gridlines.tsx
+++ b/ui/display/Gridlines.tsx
@@ -17,7 +17,6 @@ export const GridLines = ({
   animationDuration = 300, // Default duration for fade in/out
   staggerMs = 15, // Default delay between lines starting animation
 }: GridLinesProps) => {
-  console.log('render grid lines')
   const { width, height } = useWindowDimensions()
 
   const horizontalLines = []

--- a/ui/display/SearchDemo.tsx
+++ b/ui/display/SearchDemo.tsx
@@ -132,7 +132,6 @@ export const SearchDemo = () => {
     setTermIndex((prevIndex) => {
       const newIndex = prevIndex + 1
       const newTerm = terms[newIndex % terms.length]
-      console.log('SET TERM', newTerm)
       setSearchTerm(newTerm)
       return newIndex
     })
@@ -145,10 +144,6 @@ export const SearchDemo = () => {
       setResults(shuffled.slice(0, 3))
     }, 1400)
   }
-
-  useEffect(() => {
-    console.log(searchTerm, 'updated')
-  }, [searchTerm])
 
   // Start the interval timers.
   useEffect(() => {

--- a/ui/grid/DraggableGrid.tsx
+++ b/ui/grid/DraggableGrid.tsx
@@ -8,8 +8,6 @@ import { CompleteRef } from '@/features/pocketbase/stores/types'
 import { DraggableGrid as DraggableGridComponent } from 'react-native-draggable-grid'
 
 export const FlatListGrid = ({ items }: { items: CompleteRef[] }) => {
-  console.log(items.length)
-
   return (
     <FlatList
       style={{ width: '100%' }}
@@ -35,21 +33,16 @@ export const DraggableGridScrollView = ({
   children: React.ReactNode
   style?: any
 }) => {
-  console.log(style)
   const scrollViewRef = useRef<ScrollView>(null)
 
   const onDragStart = () => {
-    console.log('on drag start')
     if (scrollViewRef.current) {
-      console.log('disable scrolling')
       scrollViewRef.current.setNativeProps({ scrollEnabled: false })
     }
   }
 
   const onDragEnd = () => {
-    console.log('on drag end')
     if (scrollViewRef.current) {
-      console.log('enable scrolling')
       scrollViewRef.current.setNativeProps({ scrollEnabled: true })
     }
   }
@@ -57,8 +50,6 @@ export const DraggableGridScrollView = ({
   return (
     <ScrollView ref={scrollViewRef} style={style}>
       {React.Children.map(children, (child: any) => {
-        console.log(child?.type, child?.displayName, child?.type.name)
-        console.log(child?.type === DraggableGrid)
         if (
           React.isValidElement<{
             onDragStart: () => void
@@ -67,7 +58,6 @@ export const DraggableGridScrollView = ({
           typeof child.type !== 'string' &&
           child?.type.name === 'DraggableGrid'
         ) {
-          console.log('Attaching those things')
           return React.cloneElement(child, {
             onDragStart,
             onDragEnd,
@@ -126,9 +116,6 @@ export const DraggableGrid = ({
           onDragEnd() //This activates the above onDragEnd function when you stop dragging and just turns scrolling back on
         }}
         onDragStart={(e: { eventName: string }) => {
-          console.log('')
-          console.log('start')
-          console.log(e)
           onDragStart()
         }} //This activates the above onDragStart function when you start dragging and turns scrolling off
         numColumns={3}

--- a/ui/images/PinataImage.tsx
+++ b/ui/images/PinataImage.tsx
@@ -70,12 +70,10 @@ export const PinataImage = ({
 
   // Handle image upload
   useEffect(() => {
-    console.log('is connected from pinata ,', isConnected)
     const load = async () => {
       try {
         setLoading(true)
         const url = typeof asset === 'string' ? asset : await pinataUpload(asset)
-        console.log('got signed url')
         setPinataSource(url)
         onSuccess(url)
 

--- a/ui/inputs/Picker.tsx
+++ b/ui/inputs/Picker.tsx
@@ -12,11 +12,9 @@ export function Picker({
   disablePinata?: boolean
 }) {
   useEffect(() => {
-    console.log('PICKER')
     const pickImage = async () => {
       // No permissions request is necessary for launching the image library
       try {
-        console.log('coming up? ')
         let result = await ImagePicker.launchImageLibraryAsync({
           allowsEditing: true,
           aspect: [4, 3],
@@ -33,7 +31,6 @@ export function Picker({
           onSuccess(result.assets[0])
           // }
         } else {
-          console.log(result.canceled)
           onCancel()
         }
       } catch (e) {
@@ -44,7 +41,7 @@ export function Picker({
     pickImage()
 
     return () => {
-      console.log('picker is done')
+      // Cleanup
     }
   }, [])
 

--- a/ui/inputs/SearchBar.tsx
+++ b/ui/inputs/SearchBar.tsx
@@ -41,7 +41,6 @@ export const SearchBar = ({
   }))
 
   useEffect(() => {
-    console.log('search term updated, inner', searchTerm)
     setTextState(searchTerm)
   }, [searchTerm])
   useEffect(() => onChange(textState), [textState])
@@ -144,10 +143,6 @@ export const ControlledSearchBar = ({ searchTerm = '' }) => {
   const translateY = useAnimatedStyle(() => ({
     transform: [{ translateY: y.get() }],
   }))
-
-  useEffect(() => {
-    console.log('it changed from controlled')
-  }, [searchTerm])
 
   return (
     <View style={{ paddingHorizontal: s.$2, width: '100%' }}>

--- a/ui/lists/EditableList.tsx
+++ b/ui/lists/EditableList.tsx
@@ -38,7 +38,7 @@ export const EditableList = ({
         title: e,
       })
     } catch (error) {
-      console.log(error)
+      console.error(error)
     }
   }
 

--- a/ui/notifications/PushNotificationsSetupDemo.tsx
+++ b/ui/notifications/PushNotificationsSetupDemo.tsx
@@ -36,8 +36,7 @@ export function PushNotificationsSetupDemo() {
 
   useEffect(() => {
     const logInformation = async () => {
-      const { data: pushTokenString } = await Notifications.getExpoPushTokenAsync({ projectId })
-      console.log(pushTokenString)
+      await Notifications.getExpoPushTokenAsync({ projectId })
     }
 
     registerForPushNotificationsAsync()
@@ -49,7 +48,7 @@ export function PushNotificationsSetupDemo() {
     })
 
     responseListener.current = Notifications.addNotificationResponseReceivedListener((response) => {
-      console.log(response)
+      // log the response if we want to
     })
 
     logInformation()

--- a/ui/notifications/RegisterPushNotifications.tsx
+++ b/ui/notifications/RegisterPushNotifications.tsx
@@ -24,7 +24,6 @@ export function RegisterPushNotifications() {
 
     const logInformation = async () => {
       const { data: pushTokenString } = await Notifications.getExpoPushTokenAsync({ projectId })
-      console.log(pushTokenString)
     }
 
     registerForPushNotificationsAsync()
@@ -42,7 +41,7 @@ export function RegisterPushNotifications() {
     })
 
     responseListener.current = Notifications.addNotificationResponseReceivedListener((response) => {
-      console.log(response)
+      // log the response if we want to
     })
 
     process.env.NODE_ENV === 'development' && logInformation()

--- a/ui/notifications/utils.ts
+++ b/ui/notifications/utils.ts
@@ -40,12 +40,11 @@ export async function registerForPushNotificationsAsync() {
           projectId,
         })
       ).data
-      console.log('pushTokenString:', pushTokenString)
       return pushTokenString
     } catch (e: unknown) {
       handleRegistrationError(`${e}`)
     }
   } else {
-    console.log('Must use physical device for push notifications')
+    console.error('Must use physical device for push notifications')
   }
 }

--- a/ui/profiles/DetailsCarouselItem.tsx
+++ b/ui/profiles/DetailsCarouselItem.tsx
@@ -194,20 +194,7 @@ export const DetailsCarouselItem = ({ item, index }: { item: ExpandedItem; index
                 />
               )}
               {item.expand?.ref.image || item.image ? (
-                <Zoomable
-                  minScale={0.25}
-                  maxScale={3}
-                  isPanEnabled={true}
-                  onInteractionEnd={() => console.log('onInteractionEnd')}
-                  onPanStart={() => console.log('onPanStart')}
-                  onPanEnd={() => console.log('onPanEnd')}
-                  onPinchStart={() => console.log('onPinchStart')}
-                  onPinchEnd={() => console.log('onPinchEnd')}
-                  onSingleTap={() => console.log('onSingleTap')}
-                  onDoubleTap={(zoomType) => {
-                    console.log('onDoubleTap', zoomType)
-                  }}
-                >
+                <Zoomable minScale={0.25} maxScale={3} isPanEnabled={true}>
                   <Animated.View
                     style={[
                       animatedStyle,
@@ -418,7 +405,6 @@ export const DetailsCarouselItem = ({ item, index }: { item: ExpandedItem; index
         <Sheet
           keyboardShouldPersistTaps="always"
           onClose={() => {
-            console.log('close')
             setSearchingNewRef('')
             // Do not update the ref
           }}
@@ -427,7 +413,6 @@ export const DetailsCarouselItem = ({ item, index }: { item: ExpandedItem; index
             noNewRef
             onComplete={async (e) => {
               // Update the ref
-              console.log(e.id)
               await updateEditedState({
                 ref: e.id,
               })

--- a/ui/profiles/NewUserProfile.tsx
+++ b/ui/profiles/NewUserProfile.tsx
@@ -46,7 +46,7 @@ const EmailStep = ({ carouselRef }: { carouselRef: React.RefObject<ICarouselInst
             }
           }
         },
-        (errors) => console.log('Errors:', errors)
+        (errors) => console.error('Errors:', errors)
       )}
     >
       <Controller
@@ -96,7 +96,7 @@ const NameStep = ({ carouselRef }: { carouselRef: React.RefObject<ICarouselInsta
           updateStagedUser(values)
           carouselRef.current?.next()
         },
-        (errors) => console.log('Errors:', errors)
+        (errors) => console.error('Errors:', errors)
       )}
     >
       <Controller
@@ -163,7 +163,7 @@ const LocationStep = ({ carouselRef }: { carouselRef: React.RefObject<ICarouselI
         async (values) => {
           carouselRef.current?.next()
         },
-        (errors) => console.log('Errors:', errors)
+        (errors) => console.error('Errors:', errors)
       )}
     >
       <Controller
@@ -204,7 +204,7 @@ const PasswordStep = ({ carouselRef }: { carouselRef: React.RefObject<ICarouselI
           updateStagedUser(values)
           carouselRef.current?.next()
         },
-        (errors) => console.log('Errors:', errors)
+        (errors) => console.error('Errors:', errors)
       )}
     >
       <Controller
@@ -283,7 +283,7 @@ const ImageStep = ({ carouselRef }: { carouselRef: React.RefObject<ICarouselInst
             console.error('Nope', error)
           }
         },
-        (errors) => console.log('Errors:', errors)
+        (errors) => console.error('Errors:', errors)
       )}
     >
       <Controller
@@ -324,7 +324,7 @@ const DoneStep = ({ carouselRef }: { carouselRef: React.RefObject<ICarouselInsta
           // go back to /, clear the stack of the onboarding screens
           router.dismissAll()
         },
-        (errors) => console.log('Errors:', errors)
+        (errors) => console.error('Errors:', errors)
       )}
     >
       <FirstVisitScreen />

--- a/ui/typo/DeferredFonts.tsx
+++ b/ui/typo/DeferredFonts.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 import { useFonts } from 'expo-font'
 
 export const DeferredFonts = () => {
-  const [deferredFonts, deferredError] = useFonts({
+  const [_deferredFonts, deferredError] = useFonts({
     InterLight: require('@/assets/fonts/Inter-Light.ttf'),
     InterItalic: require('@/assets/fonts/Inter-Italic.ttf'),
     InterLightItalic: require('@/assets/fonts/Inter-LightItalic.ttf'),
@@ -10,10 +10,8 @@ export const DeferredFonts = () => {
   })
 
   useEffect(() => {
-    // console.log('something has happened indeed', deferredFonts)
-    if (deferredFonts) console.log(deferredFonts)
     if (deferredError) console.error(deferredError)
-  }, [deferredFonts, deferredError])
+  }, [deferredError])
 
   return <></>
 }


### PR DESCRIPTION
We have a lot of `console.log` statements in the current codebase. These just add to noise and make it harder to identify the actual errors, or make it difficult when inserting our own log statements when debugging issues. If we want to explicitly log an error, we should call `console.error`. We should never check in any PR that has `console.log` statements.