### PR TITLE
delete children when deleting list; get rid of removeFromProfile

### DIFF
--- a/features/pocketbase/index.tsx
+++ b/features/pocketbase/index.tsx
@@ -39,11 +39,4 @@ const addToProfile: (
   return newItem
 }
 
-const removeFromProfile = async (itemId: string) => {
-  const userStore = useUserStore.getState()
-
-  await userStore.removeItem(itemId)
-  await pocketbase.collection('items').delete(itemId)
-}
-
-export { pocketbase, useUserStore, useRefStore, useItemStore, addToProfile, removeFromProfile }
+export { pocketbase, useUserStore, useRefStore, useItemStore, addToProfile }

--- a/features/pocketbase/stores/items.ts
+++ b/features/pocketbase/stores/items.ts
@@ -95,11 +95,11 @@ export const useItemStore = create<{
   },
   remove: async (id: string): Promise<void> => {
     const item = await pocketbase.collection('items').getOne(id)
-    if (item.list)
-    {
-      const children = await pocketbase.collection('items').getFullList({filter: `parent = "${id}"`})
-      for (const child of children)
-      {
+    if (item.list) {
+      const children = await pocketbase
+        .collection('items')
+        .getFullList({ filter: `parent = "${id}"` })
+      for (const child of children) {
         await pocketbase.collection('items').delete(child.id)
       }
     }

--- a/features/pocketbase/stores/items.ts
+++ b/features/pocketbase/stores/items.ts
@@ -94,6 +94,15 @@ export const useItemStore = create<{
     }
   },
   remove: async (id: string): Promise<void> => {
+    const item = await pocketbase.collection('items').getOne(id)
+    if (item.list)
+    {
+      const children = await pocketbase.collection('items').getFullList({filter: `parent = "${id}"`})
+      for (const child of children)
+      {
+        await pocketbase.collection('items').delete(child.id)
+      }
+    }
     await pocketbase.collection('items').delete(id)
     await canvasApp.actions.removeItem(id)
 

--- a/ui/profiles/MyProfile.tsx
+++ b/ui/profiles/MyProfile.tsx
@@ -1,4 +1,4 @@
-import { pocketbase, removeFromProfile, useItemStore, useUserStore } from '@/features/pocketbase'
+import { pocketbase, useItemStore, useUserStore } from '@/features/pocketbase'
 import { getBacklogItems, getProfileItems } from '@/features/pocketbase/stores/items'
 import type { ExpandedProfile } from '@/features/pocketbase/stores/types'
 import { ExpandedItem } from '@/features/pocketbase/stores/types'
@@ -29,7 +29,7 @@ export const MyProfile = ({ userName }: { userName: string }) => {
   const [loading, setLoading] = useState<boolean>(true)
 
   const { user } = useUserStore()
-  const { moveToBacklog, profileRefreshTrigger } = useItemStore()
+  const { moveToBacklog, profileRefreshTrigger, remove } = useItemStore()
 
   const [addingTo, setAddingTo] = useState<'' | 'grid' | 'backlog'>('')
   const [removingItem, setRemovingItem] = useState<ExpandedItem | null>(null)
@@ -69,7 +69,7 @@ export const MyProfile = ({ userName }: { userName: string }) => {
   const handleRemoveFromProfile = async () => {
     if (!removingItem) return
     removeRefSheetRef.current?.close()
-    await removeFromProfile(removingItem.id)
+    await remove(removingItem.id)
     setRemovingItem(null)
     await refreshGrid(userName)
   }

--- a/ui/profiles/sheets/AddRefSheet.tsx
+++ b/ui/profiles/sheets/AddRefSheet.tsx
@@ -1,4 +1,4 @@
-import { addToProfile, pocketbase, removeFromProfile, useUserStore } from '@/features/pocketbase'
+import { addToProfile, pocketbase, useUserStore } from '@/features/pocketbase'
 import { getProfileItems, useItemStore } from '@/features/pocketbase/stores/items'
 import { ExpandedItem } from '@/features/pocketbase/stores/types'
 import { c, s } from '@/features/style'
@@ -12,7 +12,6 @@ import { Text, View } from 'react-native'
 import Animated, { FadeIn, FadeOut } from 'react-native-reanimated'
 import { AddRefSheetGrid } from './AddRefSheetGrid'
 import { useUIStore } from '@/ui/state'
-import { FilteredItems } from '@/ui/actions/FilteredItems'
 
 export const AddRefSheet = ({
   bottomSheetRef,
@@ -24,7 +23,7 @@ export const AddRefSheet = ({
   const [refData, setRefData] = useState<any>({})
 
   const [gridItems, setGridItems] = useState<ExpandedItem[]>([])
-  const { moveToBacklog } = useItemStore()
+  const { moveToBacklog, remove } = useItemStore()
 
   useEffect(() => {
     const fetchGridItems = async () => {
@@ -223,7 +222,7 @@ export const AddRefSheet = ({
             variant="basic"
             onPress={async () => {
               // remove the item
-              await removeFromProfile(itemToReplace.id)
+              await remove(itemToReplace.id)
               await addToProfile(refData, {
                 backlog: false,
                 text: '',


### PR DESCRIPTION
- delete list children when deleting a list
- replace removeFromProfile with remove, since we're no longer using the 'items' field in 'users', so we don't need to remove items from it when we delete them. we can remove this field from pocketbase after we make sure it's not actually used anywhere