### PR TITLE
Add `promptContext` column to `items` table

### DIFF
--- a/features/pocketbase/schema.json
+++ b/features/pocketbase/schema.json
@@ -1165,6 +1165,20 @@
         "type": "relation"
       },
       {
+        "autogeneratePattern": "",
+        "hidden": false,
+        "id": "text4075943792",
+        "max": 0,
+        "min": 0,
+        "name": "promptContext",
+        "pattern": "",
+        "presentable": false,
+        "primaryKey": false,
+        "required": false,
+        "system": false,
+        "type": "text"
+      },
+      {
         "hidden": false,
         "id": "autodate2990389176",
         "name": "created",

--- a/features/pocketbase/stores/pocketbase-types.ts
+++ b/features/pocketbase/stores/pocketbase-types.ts
@@ -136,6 +136,7 @@ export type ItemsRecord = {
   text?: string
   updated?: IsoDateString
   url?: string
+  promptContext?: string
 }
 
 export type MembershipsRecord = {


### PR DESCRIPTION
Fixes #286 

I've added the column to our running PocketBase instance. This PR consists of the updated PocketBase schema and the updated type definition.