### PR TITLE
Use concrete types for state update methods

### DIFF
--- a/features/pocketbase/index.tsx
+++ b/features/pocketbase/index.tsx
@@ -19,14 +19,15 @@ const addToProfile = async (
 
   if (existingRefId) {
     // create a new item from an existing ref
-    newItem = await itemStore.push({
-      creator: userStore.user.id,
-      ref: existingRefId,
-      image: stagedItemFields.image,
-      url: stagedItemFields.url,
-      text: stagedItemFields.text,
-      backlog,
-    })
+    newItem = await itemStore.push(
+      existingRefId,
+      {
+        image: stagedItemFields.image,
+        url: stagedItemFields.url,
+        text: stagedItemFields.text,
+      },
+      backlog
+    )
   } else {
     // create a new item, with a new ref
     const newRef = await itemStore.pushRef({
@@ -35,14 +36,15 @@ const addToProfile = async (
       meta: stagedItemFields.meta,
       image: stagedItemFields.image,
     })
-    newItem = await itemStore.push({
-      creator: userStore.user.id,
-      ref: newRef.id,
-      image: stagedItemFields.image,
-      url: stagedItemFields.url,
-      text: stagedItemFields.text,
-      backlog,
-    })
+    newItem = await itemStore.push(
+      newRef.id,
+      {
+        image: stagedItemFields.image,
+        url: stagedItemFields.url,
+        text: stagedItemFields.text,
+      },
+      backlog
+    )
   }
 
   return newItem

--- a/features/pocketbase/index.tsx
+++ b/features/pocketbase/index.tsx
@@ -8,14 +8,9 @@ const addToProfile = async (
   stagedItemFields: StagedItemFields,
   backlog: boolean
 ): Promise<ExpandedItem> => {
-  const userStore = useUserStore.getState()
   const itemStore = useItemStore.getState()
 
   let newItem: ExpandedItem
-
-  if (!userStore.user) {
-    throw new Error('User not found')
-  }
 
   if (existingRefId) {
     // create a new item from an existing ref
@@ -31,7 +26,6 @@ const addToProfile = async (
   } else {
     // create a new item, with a new ref
     const newRef = await itemStore.pushRef({
-      creator: userStore.user.id,
       title: stagedItemFields.title,
       meta: stagedItemFields.meta,
       image: stagedItemFields.image,

--- a/features/pocketbase/stores/canvas.ts
+++ b/features/pocketbase/stores/canvas.ts
@@ -137,7 +137,10 @@ class RefsContract extends Contract<typeof RefsContract.models> {
     this.db.delete('ref', refId)
   }
 
-  async updateUser(userId: string, fields: Partial<Profile>) {
+  async updateUser(
+    userId: string,
+    fields: { location?: string; lon?: number; lat?: number; pushToken?: string }
+  ) {
     const user = await this.db.get('user', userId)
     if (user === null) throw new Error('invalid userId')
     this.db.set('user', { ...user, ...fields })

--- a/features/pocketbase/stores/items.ts
+++ b/features/pocketbase/stores/items.ts
@@ -50,7 +50,7 @@ export const useItemStore = create<{
   triggerFeedRefresh: () => void
   triggerProfileRefresh: () => void
   pushRef: (stagedRef: StagedRef) => Promise<RecordModel>
-  updateOneRef: (id: string, fields: Partial<StagedRef>) => Promise<RecordModel>
+  updateRefTitle: (id: string, title: string) => Promise<RecordModel>
 }>((set, get) => ({
   addingToList: false,
   editing: '',
@@ -162,9 +162,9 @@ export const useItemStore = create<{
 
     return record
   },
-  updateOneRef: async (id: string, fields: Partial<StagedRef>) => {
+  updateRefTitle: async (id: string, title: string) => {
     try {
-      const record = await pocketbase.collection('refs').update(id, { ...fields })
+      const record = await pocketbase.collection('refs').update(id, { title })
       return record
     } catch (error) {
       console.error(error)

--- a/features/pocketbase/stores/items.ts
+++ b/features/pocketbase/stores/items.ts
@@ -1,7 +1,7 @@
 import { pocketbase } from '../pocketbase'
 import { RecordModel } from 'pocketbase'
 import { create } from 'zustand'
-import { StagedItem, ExpandedItem, CompleteRef, StagedRef } from './types'
+import { StagedItem, ExpandedItem, CompleteRef } from './types'
 import { ItemsRecord } from './pocketbase-types'
 import { canvasApp } from './canvas'
 import { createdSort } from '@/ui/profiles/sorts'
@@ -49,7 +49,13 @@ export const useItemStore = create<{
   moveToBacklog: (id: string) => Promise<ItemsRecord>
   triggerFeedRefresh: () => void
   triggerProfileRefresh: () => void
-  pushRef: (stagedRef: StagedRef) => Promise<RecordModel>
+  pushRef: (stagedRef: {
+    creator: string
+    title?: string
+    meta?: string
+    image?: string
+    type?: string
+  }) => Promise<RecordModel>
   updateRefTitle: (id: string, title: string) => Promise<RecordModel>
 }>((set, get) => ({
   addingToList: false,
@@ -156,7 +162,7 @@ export const useItemStore = create<{
       throw error
     }
   },
-  pushRef: async (stagedRef: StagedRef) => {
+  pushRef: async (stagedRef) => {
     const record = await pocketbase.collection('refs').create(stagedRef)
     await canvasApp.actions.pushRef({ ...stagedRef, id: record.id })
 

--- a/features/pocketbase/stores/types.ts
+++ b/features/pocketbase/stores/types.ts
@@ -35,3 +35,10 @@ export type StagedItemFields = {
   list?: boolean
   parent?: string
 }
+
+export type StagedRefFields = {
+  title?: string
+  meta?: string
+  image?: string
+  type?: string
+}

--- a/features/pocketbase/stores/types.ts
+++ b/features/pocketbase/stores/types.ts
@@ -1,6 +1,5 @@
 import * as PBTypes from './pocketbase-types'
 
-export type StagedRef = Partial<PBTypes.RefsRecord>
 export type StagedItem = Partial<PBTypes.ItemsRecord>
 
 export type CompleteRef = PBTypes.RefsRecord

--- a/features/pocketbase/stores/types.ts
+++ b/features/pocketbase/stores/types.ts
@@ -1,7 +1,5 @@
 import * as PBTypes from './pocketbase-types'
 
-export type StagedItem = Partial<PBTypes.ItemsRecord>
-
 export type CompleteRef = PBTypes.RefsRecord
 export type Profile = PBTypes.UsersRecord
 export type Item = PBTypes.ItemsRecord
@@ -34,4 +32,6 @@ export type StagedItemFields = {
   text: string
   url: string
   image: string
+  list?: boolean
+  parent?: string
 }

--- a/ui/actions/RefForm.tsx
+++ b/ui/actions/RefForm.tsx
@@ -17,7 +17,7 @@ import { EditableHeader } from '../atoms/EditableHeader'
 import { Button } from '../buttons/Button'
 import type { ImagePickerAsset } from 'expo-image-picker'
 import { c, s } from '@/features/style'
-import { StagedItemFields, StagedRef } from '@/features/pocketbase/stores/types'
+import { StagedItemFields } from '@/features/pocketbase/stores/types'
 // @ts-ignore
 import { KeyboardAvoidingView } from 'react-native-keyboard-controller'
 import { DismissKeyboard } from '../atoms/DismissKeyboard'

--- a/ui/lists/EditableList.tsx
+++ b/ui/lists/EditableList.tsx
@@ -21,20 +21,18 @@ export const EditableList = ({
   onComplete: () => void
 }) => {
   const { addingToList, remove, setAddingToList } = useItemStore()
-  const { push, updateOneRef } = useItemStore()
+  const { push, updateRefTitle } = useItemStore()
   const [itemState, setItemState] = useState<ExpandedItem>(item)
   const [title, setTitle] = useState<string>(item.expand.ref.title || '')
   const [editingTitle, setEditingTitle] = useState<boolean>(!item.expand.ref.title)
   const titleRef = useRef<any>(null)
   const insets = useSafeAreaInsets()
 
-  const onTitleChange = async (e: string) => {
+  const onTitleChange = async (newTitle: string) => {
     titleRef.current?.blur()
     setEditingTitle(false)
     try {
-      await updateOneRef(item.ref, {
-        title: e,
-      })
+      await updateRefTitle(item.ref, newTitle)
     } catch (error) {
       console.error(error)
     }

--- a/ui/lists/EditableList.tsx
+++ b/ui/lists/EditableList.tsx
@@ -40,12 +40,17 @@ export const EditableList = ({
 
   const onRefFound = async (ref: CompleteRef) => {
     try {
-      const newItem = await push({
-        ref: ref.id,
-        image: ref?.image,
-        creator: pocketbase.authStore?.record?.id,
-        parent: item.id,
-      })
+      const newItem = await push(
+        ref.id,
+        {
+          image: ref?.image || '',
+
+          parent: item.id,
+          text: '',
+          url: '',
+        },
+        false
+      )
       setItemState((prev) => ({
         ...prev,
         expand: {

--- a/ui/profiles/sheets/NewRefSheet.tsx
+++ b/ui/profiles/sheets/NewRefSheet.tsx
@@ -240,7 +240,7 @@ export const NewRefSheet = ({
                   const listRef = await pushRef({
                     title: '',
                     type: RefsTypeOptions.other,
-                    creator: user?.id,
+                    creator: user?.id!,
                   })
 
                   // Create new item with the ref

--- a/ui/profiles/sheets/NewRefSheet.tsx
+++ b/ui/profiles/sheets/NewRefSheet.tsx
@@ -240,7 +240,6 @@ export const NewRefSheet = ({
                   const listRef = await pushRef({
                     title: '',
                     type: RefsTypeOptions.other,
-                    creator: user?.id!,
                   })
 
                   // Create new item with the ref

--- a/ui/profiles/sheets/NewRefSheet.tsx
+++ b/ui/profiles/sheets/NewRefSheet.tsx
@@ -244,11 +244,16 @@ export const NewRefSheet = ({
                   })
 
                   // Create new item with the ref
-                  const list = await pushItem({
-                    ref: listRef.id,
-                    creator: user?.id,
-                    list: true,
-                  })
+                  const list = await pushItem(
+                    listRef.id,
+                    {
+                      list: true,
+                      text: '',
+                      url: '',
+                      image: '',
+                    },
+                    false
+                  )
 
                   // Add current item to the new list
                   await addItemToList(list.id, itemData?.id!)


### PR DESCRIPTION
Refactor split out of https://github.com/refs-nyc/refs/pull/285 

We are using types like `Partial<...>` in a number of places, but interfaces like Canvas require us to be explicit about which fields we are passing in. In reality, there are only a few fields we are interested in, which can be edited in the new ref dialog (title, text, image, meta, which are now in `StagedRefFields` and `StagedItemFields`) and some that are contextual (backlog) and some that come from the current pocketbase login state (creator). Hopefully this change makes it a bit easier to follow.