### PR TITLE
Fix 293

### DIFF
--- a/ui/actions/RefForm.tsx
+++ b/ui/actions/RefForm.tsx
@@ -7,8 +7,8 @@ import {
   Text,
   Pressable,
   ActivityIndicator,
+  TextInput
 } from 'react-native'
-import { BottomSheetTextInput as TextInput } from '@gorhom/bottom-sheet'
 import { Heading } from '@/ui/typo/Heading'
 import { Picker } from '../inputs/Picker'
 import { PinataImage } from '../images/PinataImage'
@@ -18,8 +18,6 @@ import { Button } from '../buttons/Button'
 import type { ImagePickerAsset } from 'expo-image-picker'
 import { c, s } from '@/features/style'
 import { StagedItemFields } from '@/features/pocketbase/stores/types'
-// @ts-ignore
-import { KeyboardAvoidingView } from 'react-native-keyboard-controller'
 import { DismissKeyboard } from '../atoms/DismissKeyboard'
 
 const win = Dimensions.get('window')
@@ -135,7 +133,7 @@ export const RefForm = ({
 
   return (
     <DismissKeyboard>
-      <KeyboardAvoidingView
+      <View
         style={{
           justifyContent: 'flex-start',
           alignItems: 'center',
@@ -144,8 +142,6 @@ export const RefForm = ({
           marginBottom: s.$2 + 10,
           width: '100%',
         }}
-        behavior="padding"
-        keyboardVerticalOffset={Dimensions.get('window').height * 0.25}
       >
         <View
           style={{
@@ -496,7 +492,7 @@ export const RefForm = ({
             />
           )}
         </View>
-      </KeyboardAvoidingView>
+      </View>
     </DismissKeyboard>
   )
 }

--- a/ui/actions/RefForm.tsx
+++ b/ui/actions/RefForm.tsx
@@ -7,8 +7,8 @@ import {
   Text,
   Pressable,
   ActivityIndicator,
-  TextInput
 } from 'react-native'
+import { BottomSheetScrollView, BottomSheetTextInput as TextInput } from '@gorhom/bottom-sheet'
 import { Heading } from '@/ui/typo/Heading'
 import { Picker } from '../inputs/Picker'
 import { PinataImage } from '../images/PinataImage'
@@ -133,14 +133,13 @@ export const RefForm = ({
 
   return (
     <DismissKeyboard>
-      <View
-        style={{
-          justifyContent: 'flex-start',
-          alignItems: 'center',
+      <BottomSheetScrollView
+        contentContainerStyle={{
           gap: s.$1,
           marginTop: s.$2,
           marginBottom: s.$2 + 10,
-          width: '100%',
+          justifyContent: 'flex-start',
+          alignItems: 'center',
         }}
       >
         <View
@@ -492,7 +491,7 @@ export const RefForm = ({
             />
           )}
         </View>
-      </View>
+      </BottomSheetScrollView>
     </DismissKeyboard>
   )
 }

--- a/ui/actions/SearchRef.tsx
+++ b/ui/actions/SearchRef.tsx
@@ -266,7 +266,7 @@ export const SearchRef = ({
 
   return (
     <>
-      <KeyboardAvoidingView style={{ width: '100%' }}>
+      <View style={{ width: '100%' }}>
         <View
           style={{
             flexDirection: 'row',
@@ -380,7 +380,7 @@ export const SearchRef = ({
         >
           {searchResults.map((r) => renderItem({ item: r }))}
         </YStack>
-      </KeyboardAvoidingView>
+      </View>
     </>
   )
 }

--- a/ui/profiles/sheets/NewRefSheet.tsx
+++ b/ui/profiles/sheets/NewRefSheet.tsx
@@ -62,7 +62,7 @@ export const NewRefSheet = ({
   const backlog = addingNewRefTo === 'backlog'
 
   // Two snap points: collapsed and expanded
-  const snapPoints = ['50%', '90%']
+  const snapPoints = ['70%', '90%']
   // Track if the sheet is open
   const [isSheetOpen, setIsSheetOpen] = useState(false)
 
@@ -112,7 +112,7 @@ export const NewRefSheet = ({
           pressBehavior={'close'}
         />
       )}
-      keyboardBehavior="interactive"
+      // keyboardBehavior="interactive"
     >
       {isOpen && (
         <BottomSheetView


### PR DESCRIPTION
Fix the bug in #293 - it turns out that in some of the views (search, add ref), the "avoid keyboard" behaviour was clashing with the change here: https://github.com/refs-nyc/refs/commit/951a15ea4f50382921a3bc60d279409de1a5c7db#diff-7a94ea5ed92fa0d21232f870198dad78447ed6797dbc1c0b628268a9b36a7b52L64


QA:
- [x] Click "Add Ref +" from feed, type in search form, turn keyboard on and off
- [x] Proceed to "edit ref" view, turn keyboard on and off

