### PR TITLE
Remove "deleted" columns from "items" and "refs"

### DIFF
--- a/features/pocketbase/pocketbase-types.ts
+++ b/features/pocketbase/pocketbase-types.ts
@@ -122,7 +122,6 @@ export type ItemsRecord = {
   backlog?: boolean
   created?: IsoDateString
   creator?: RecordIdString
-  deleted?: IsoDateString
   id: string
   image?: string
   list?: boolean
@@ -172,7 +171,6 @@ export enum RefsTypeOptions {
 export type RefsRecord = {
   created?: IsoDateString
   creator?: RecordIdString
-  deleted?: IsoDateString
   id: string
   image?: string
   meta?: string

--- a/features/pocketbase/schema.json
+++ b/features/pocketbase/schema.json
@@ -1170,16 +1170,6 @@
         "presentable": false,
         "system": false,
         "type": "autodate"
-      },
-      {
-        "hidden": false,
-        "id": "autodate3946532403",
-        "name": "deleted",
-        "onCreate": true,
-        "onUpdate": false,
-        "presentable": false,
-        "system": false,
-        "type": "autodate"
       }
     ],
     "indexes": [],
@@ -1600,16 +1590,6 @@
         "name": "updated",
         "onCreate": true,
         "onUpdate": true,
-        "presentable": false,
-        "system": false,
-        "type": "autodate"
-      },
-      {
-        "hidden": false,
-        "id": "autodate3946532403",
-        "name": "deleted",
-        "onCreate": true,
-        "onUpdate": false,
         "presentable": false,
         "system": false,
         "type": "autodate"


### PR DESCRIPTION
Fixes #303 

We aren't using these anywhere in the code (items/refs that are deleted are deleted from the database, so they don't have any columns)