### PR TITLE
Fix search results sheet dip and re-rise when restoring from history

### DIFF
--- a/ui/navigation/Navigation.tsx
+++ b/ui/navigation/Navigation.tsx
@@ -24,40 +24,28 @@ export const Navigation = ({
     messagesPerConversation,
     conversations,
     memberships,
-    selectedRefs,
+    returningFromSearchNavigation,
     cachedSearchResults,
-    setReturningFromSearchViaBackButton,
-    setReturningFromSearch,
   } = useAppStore()
 
   const isHomePage = pathname === '/' || pathname === '/index'
 
   const scaleAnim = useRef(new Animated.Value(1)).current
 
-  // Custom back button handler for search results
+  // Enhanced back button handler that preserves search context
   const handleBackPress = () => {
-    // Check if we're on a user profile page and have search context
-    if (
-      pathname.startsWith('/user/') &&
-      (selectedRefs.length > 0 || cachedSearchResults.length > 0)
-    ) {
-      // Set the specific flag for back button navigation
-      setReturningFromSearchViaBackButton(true)
-      // Navigate back to the current user's profile page
-      router.push(`/user/${user?.userName}`)
-      // Open the search results sheet after a brief delay for smooth UX
-      setTimeout(() => {
-        if (selectedRefs.length > 0 || cachedSearchResults.length > 0) {
-          // Trigger the search results sheet to open
-          setReturningFromSearch(true)
-          setReturningFromSearchViaBackButton(true) // Also set this flag so MyProfile knows it's from back button
-        } else {
-        }
-      }, 100) // Small delay to ensure navigation completes first
-    } else {
-      // Default back behavior
-      router.back()
+    // Check if we're returning from search navigation and have search context
+    if (returningFromSearchNavigation && cachedSearchResults.length > 0) {
+      // Navigate back to the current user's profile with search context preserved
+      const currentUser = user?.userName
+      if (currentUser) {
+        router.push(`/user/${currentUser}`)
+        return
+      }
     }
+    
+    // Default back behavior
+    router.back()
   }
 
   const animateBadge = () => {

--- a/ui/profiles/MyProfile.tsx
+++ b/ui/profiles/MyProfile.tsx
@@ -28,8 +28,7 @@ export const MyProfile = ({ userName }: { userName: string }) => {
   const [gridItems, setGridItems] = useState<ExpandedItem[]>([])
   const [backlogItems, setBacklogItems] = useState<ExpandedItem[]>([])
   const [loading, setLoading] = useState<boolean>(true)
-  const [isOpeningSearchResults, setIsOpeningSearchResults] = useState(false)
-  const [restoredRefItems, setRestoredRefItems] = useState<any[]>([])
+
 
   const {
     user,
@@ -45,26 +44,26 @@ export const MyProfile = ({ userName }: { userName: string }) => {
     searchMode,
     selectedRefs,
     selectedRefItems: globalSelectedRefItems,
-    returningFromSearch,
-    returningFromSearchViaBackButton,
     cachedSearchResults,
     isSearchResultsSheetOpen,
     setSearchMode,
     setSelectedRefs,
     setSelectedRefItems: setGlobalSelectedRefItems,
-    setReturningFromSearch,
-    setReturningFromSearchViaBackButton,
     cachedRefTitles,
     cachedRefImages,
     cachedSearchTitle,
     cachedSearchSubtitle,
     clearCachedSearchResults,
+    returningFromSearchNavigation,
+    setReturningFromSearchNavigation,
+    setSearchResultsSheetOpen,
   } = useAppStore()
 
   const [removingItem, setRemovingItem] = useState<ExpandedItem | null>(null)
 
-  // Search-related refs
+  // Refs
   const searchResultsSheetRef = useRef<BottomSheet>(null)
+  const isExpandingSheetRef = useRef(false) // Track if we're already expanding the sheet
   const searchResultsSheetTriggerRef = useRef<SearchResultsSheetRef>(null)
 
   // Simple cache to avoid refetching the same data
@@ -101,13 +100,8 @@ export const MyProfile = ({ userName }: { userName: string }) => {
     }).filter(Boolean)
   }, [selectedRefs, gridItemsMap])
 
-  // Debug: Log what selectedRefItems are being passed to SearchResultsSheet
-  const finalSelectedRefItems =
-    restoredRefItems.length > 0
-      ? restoredRefItems
-      : globalSelectedRefItems.length > 0
-      ? globalSelectedRefItems
-      : selectedRefItems
+  // Use the selectedRefItems directly
+  const finalSelectedRefItems = selectedRefItems
 
 
 
@@ -178,104 +172,111 @@ export const MyProfile = ({ userName }: { userName: string }) => {
     }, 0)
   }, [userName, profileRefreshTrigger])
 
-  // Check if we're returning from a search result and should open search results sheet
+  // Simple back button restoration logic
   useEffect(() => {
-    // Only open search results if we're returning via back button specifically
-    if (!returningFromSearchViaBackButton) {
-      // Clear the general returningFromSearch flag if we're not coming via back button
-      if (returningFromSearch) {
-        setReturningFromSearch(false)
+    // Only restore if we're returning from search navigation and have cached results
+    if (returningFromSearchNavigation && cachedSearchResults.length > 0) {
+      console.log('🔍 Returning from search navigation, restoring search context...')
+      console.log('Cached results:', cachedSearchResults.length)
+      
+      // Prevent multiple simultaneous expansions
+      if (isExpandingSheetRef.current) {
+        console.log('⏸️ Sheet expansion already in progress, skipping...')
+        return
       }
-      return
-    }
-
-    // If returning from search but selectedRefs is empty, try to reconstruct from cached ref data
-    if (returningFromSearch && selectedRefs.length === 0 && cachedRefTitles.length > 0) {
-      // Reconstruct ref IDs from cached ref titles (these are the original ref items used for search)
-      const refIds = cachedRefTitles.map((_, index) => `ref_${index}`) // Generate ref IDs based on count
-      if (refIds.length > 0) {
-        setSelectedRefs(refIds)
-        return // Exit early, let the next useEffect run handle opening the sheet
-      }
-    }
-
-
-
-    
-    // SIMPLE: Just ensure we have the right selectedRefItems for the sheet
-    if (returningFromSearch && selectedRefs.length > 0 && cachedRefTitles.length > 0) {
-      // Create the items that the SearchResultsSheet needs for thumbnails
-      const items = selectedRefs.map((refId: string, index: number) => ({
-        id: refId,
-        ref: refId,
-        image: cachedRefImages[index] || '',
-        title: cachedRefTitles[index] || refId,
-        expand: {
-          ref: {
-            id: refId,
-            title: cachedRefTitles[index] || refId,
-            image: cachedRefImages[index] || '',
-          },
-        },
-      }))
-
-      setRestoredRefItems(items)
-      setGlobalSelectedRefItems(items)
-    }
-
-    if (
-      returningFromSearch &&
-      selectedRefs.length > 0 &&
-      !isOpeningSearchResults
-    ) {
-      setIsOpeningSearchResults(true)
-      setSearchMode(false)
-      // Add a small delay to ensure proper state updates
-      setTimeout(() => {
+      
+      // Small delay to ensure navigation is complete
+      const timer = setTimeout(() => {
         if (searchResultsSheetRef.current) {
           try {
-            searchResultsSheetRef.current.snapToIndex(1)
+            console.log('📱 Attempting to expand search results sheet...')
+            isExpandingSheetRef.current = true
+            
+            // First try to ensure the sheet is in a valid state
+            searchResultsSheetRef.current.snapToIndex(0)
+            setTimeout(() => {
+              searchResultsSheetRef.current?.snapToIndex(1)
+              setSearchResultsSheetOpen(true)
+              isExpandingSheetRef.current = false
+              console.log('✅ Successfully expanded search results sheet')
+            }, 100)
           } catch (error) {
-            // Fallback: try index 0 if index 1 fails
+            console.log('❌ Failed to expand search results sheet:', error)
+            // Fallback: try the expand method
             try {
-              searchResultsSheetRef.current.snapToIndex(0)
+              searchResultsSheetRef.current.expand()
+              setSearchResultsSheetOpen(true)
+              isExpandingSheetRef.current = false
+              console.log('✅ Successfully expanded search results sheet with fallback')
             } catch (fallbackError) {
-              // Sheet failed to open
+              console.log('❌ Failed to open search results sheet with fallback:', fallbackError)
+              setReturningFromSearchNavigation(false)
+              isExpandingSheetRef.current = false
             }
           }
+        } else {
+          console.log('❌ Search results sheet ref is null')
+          setReturningFromSearchNavigation(false)
+          isExpandingSheetRef.current = false
         }
-        // Clear the back button flag after opening the sheet
-        setReturningFromSearchViaBackButton(false)
-        // Reset the flag after a longer delay
-        setTimeout(() => setIsOpeningSearchResults(false), 200)
-      }, 50)
-    } else if (
-      returningFromSearch &&
-      selectedRefs.length === 0 &&
-      cachedSearchResults.length === 0
-    ) {
-      setReturningFromSearch(false)
-      setReturningFromSearchViaBackButton(false)
+      }, 200) // Increased delay to ensure navigation is complete
+      
+      return () => clearTimeout(timer)
+    } else if (returningFromSearchNavigation) {
+      console.log('🔍 Returning from search navigation but no cached results')
+      setReturningFromSearchNavigation(false)
+    } else {
+      console.log('🔍 Not returning from search navigation')
     }
-  }, [
-    returningFromSearch,
-    returningFromSearchViaBackButton,
-    selectedRefs,
-    cachedSearchResults,
-    setReturningFromSearch,
-    setReturningFromSearchViaBackButton,
-    setSelectedRefs,
-    loading,
-    gridItems?.length || 0,
-  ])
+  }, [returningFromSearchNavigation, cachedSearchResults.length, userName, setReturningFromSearchNavigation, setSearchResultsSheetOpen])
+
+  // Additional effect to handle navigation back to profile with search context
+  useEffect(() => {
+    // If we have cached search results and we're on the profile page, 
+    // and we're not already in search mode, restore the search context
+    // But don't expand if we're already returning from search navigation
+    if (cachedSearchResults.length > 0 && !searchMode && !isSearchResultsSheetOpen && !returningFromSearchNavigation) {
+      console.log('🔍 Detected cached search results on profile page, restoring...')
+      
+      // Prevent multiple simultaneous expansions
+      if (isExpandingSheetRef.current) {
+        console.log('⏸️ Sheet expansion already in progress, skipping...')
+        return
+      }
+      
+      // Small delay to ensure component is fully mounted
+      const timer = setTimeout(() => {
+        if (searchResultsSheetRef.current) {
+          try {
+            console.log('📱 Attempting to expand search results sheet from cached results...')
+            isExpandingSheetRef.current = true
+            
+            // First try to ensure the sheet is in a valid state
+            searchResultsSheetRef.current.snapToIndex(0)
+            setTimeout(() => {
+              searchResultsSheetRef.current?.snapToIndex(1)
+              setSearchResultsSheetOpen(true)
+              isExpandingSheetRef.current = false
+              console.log('✅ Successfully expanded search results sheet from cached results')
+            }, 100)
+          } catch (error) {
+            console.log('❌ Failed to expand search results sheet from cached results:', error)
+            isExpandingSheetRef.current = false
+          }
+        }
+      }, 300)
+      
+      return () => clearTimeout(timer)
+    }
+  }, [cachedSearchResults.length, searchMode, isSearchResultsSheetOpen, userName, setSearchResultsSheetOpen, returningFromSearchNavigation])
 
   // Reset search mode when component unmounts or user navigates away
   useEffect(() => {
     return () => {
       // Cleanup: reset search mode when leaving the screen
-      // But preserve selectedRefs if we're returning from search
+      // But preserve selectedRefs and cachedSearchResults for back button restoration
       setSearchMode(false)
-      // Don't clear selectedRefs here - let the returningFromSearch logic handle it
+      // Don't clear selectedRefs or cachedSearchResults here - preserve them for back button
     }
   }, [setSearchMode])
 
@@ -397,7 +398,7 @@ export const MyProfile = ({ userName }: { userName: string }) => {
               <FloatingJaggedButton
                 onPress={() => {
                   // Don't clear selectedRefs if we're returning from search
-                  if (!returningFromSearch) {
+                  if (!searchMode) { // Changed from returningFromSearch to searchMode
                     setSelectedRefs([]) // Clear selected refs when entering search mode
                   }
                   clearCachedSearchResults() // Clear cached search results
@@ -434,7 +435,7 @@ export const MyProfile = ({ userName }: { userName: string }) => {
               onPress={() => {
                 setSearchMode(false)
                 // Don't clear selectedRefs if we're returning from search
-                if (!returningFromSearch) {
+                if (!searchMode) { // Changed from returningFromSearch to searchMode
                   setSelectedRefs([])
                 }
               }}
@@ -453,7 +454,7 @@ export const MyProfile = ({ userName }: { userName: string }) => {
               onPress={() => {
                 setSearchMode(false)
                 // Don't clear selectedRefs if we're returning from search
-                if (!returningFromSearch) {
+                if (!searchMode) { // Changed from returningFromSearch to searchMode
                   setSelectedRefs([])
                 }
               }}
@@ -472,7 +473,7 @@ export const MyProfile = ({ userName }: { userName: string }) => {
               onPress={() => {
                 setSearchMode(false)
                 // Don't clear selectedRefs if we're returning from search
-                if (!returningFromSearch) {
+                if (!searchMode) { // Changed from returningFromSearch to searchMode
                   setSelectedRefs([])
                 }
               }}
@@ -491,7 +492,7 @@ export const MyProfile = ({ userName }: { userName: string }) => {
               onPress={() => {
                 setSearchMode(false)
                 // Don't clear selectedRefs if we're returning from search
-                if (!returningFromSearch) {
+                if (!searchMode) { // Changed from returningFromSearch to searchMode
                   setSelectedRefs([])
                 }
               }}
@@ -550,7 +551,7 @@ export const MyProfile = ({ userName }: { userName: string }) => {
               selectedRefItems={selectedRefItems}
               onSearch={() => {
                 // Clear restored ref items for new searches
-                setRestoredRefItems([])
+        
                 setGlobalSelectedRefItems([]) // Also clear global state
                 searchResultsSheetRef.current?.snapToIndex(1)
                 setSearchMode(false) // Exit search mode when opening search results
@@ -564,6 +565,11 @@ export const MyProfile = ({ userName }: { userName: string }) => {
               }}
               onRestoreSearch={async (historyItem) => {
                 try {
+                  console.log('🔄 Restoring search from history with refs:', historyItem.ref_ids)
+                  
+                  // Set flag to indicate we're returning from search navigation BEFORE setting cached results
+                  setReturningFromSearchNavigation(true)
+                  
                   // Create ref items from history data with images
                   const restoredItems = historyItem.ref_ids.map((refId: string, index: number) => ({
                     id: refId,
@@ -579,13 +585,15 @@ export const MyProfile = ({ userName }: { userName: string }) => {
                     },
                   }))
 
-                  setRestoredRefItems(restoredItems)
+                  // Set the selected refs and items so the SearchResultsSheet doesn't show validation error
+                  setSelectedRefs(historyItem.ref_ids)
+                  setGlobalSelectedRefItems(restoredItems)
 
                   // Open the search results sheet immediately
                   searchResultsSheetRef.current?.snapToIndex(1)
                   setSearchMode(false)
 
-                  // Use the cached search results from history
+                  // Use the cached search results from history AFTER setting the flag
                   setTimeout(() => {
                     if (searchResultsSheetTriggerRef.current) {
                       searchResultsSheetTriggerRef.current.restoreSearchFromHistory(historyItem)

--- a/ui/state.ts
+++ b/ui/state.ts
@@ -29,8 +29,6 @@ export type UISlice = {
   searchMode: boolean
   selectedRefs: string[]
   selectedRefItems: any[]
-  returningFromSearch: boolean
-  returningFromSearchViaBackButton: boolean
   cachedSearchResults: any[]
   cachedSearchTitle: string
   cachedSearchSubtitle: string
@@ -38,14 +36,14 @@ export type UISlice = {
   cachedRefImages: string[]
   closeActiveBottomSheet: (() => void) | null
   isSearchResultsSheetOpen: boolean
+  returningFromSearchNavigation: boolean // Track when returning from search navigation
   setSearchMode: (mode: boolean) => void
   setSelectedRefs: (refs: string[]) => void
   setSelectedRefItems: (items: any[]) => void
-  setReturningFromSearch: (returning: boolean) => void
-  setReturningFromSearchViaBackButton: (returning: boolean) => void
   setCachedSearchResults: (results: any[], title: string, subtitle: string, refTitles?: string[], refImages?: string[]) => void
   clearCachedSearchResults: () => void
   setSearchResultsSheetOpen: (open: boolean) => void
+  setReturningFromSearchNavigation: (returning: boolean) => void
   setCloseActiveBottomSheet: (closeFunction: (() => void) | null) => void
 }
 
@@ -105,8 +103,6 @@ export const createUISlice: StateCreator<StoreSlices, [], [], UISlice> = (set) =
   searchMode: false,
   selectedRefs: [],
   selectedRefItems: [],
-  returningFromSearch: false,
-  returningFromSearchViaBackButton: false,
   cachedSearchResults: [],
   cachedSearchTitle: '',
   cachedSearchSubtitle: '',
@@ -114,6 +110,7 @@ export const createUISlice: StateCreator<StoreSlices, [], [], UISlice> = (set) =
   cachedRefImages: [] as string[],
   closeActiveBottomSheet: null as (() => void) | null,
   isSearchResultsSheetOpen: false,
+  returningFromSearchNavigation: false, // Track when returning from search navigation
   setSearchMode: (mode: boolean) => {
     set(() => ({
       searchMode: mode,
@@ -127,16 +124,6 @@ export const createUISlice: StateCreator<StoreSlices, [], [], UISlice> = (set) =
   setSelectedRefItems: (items: any[]) => {
     set(() => ({
       selectedRefItems: items,
-    }))
-  },
-  setReturningFromSearch: (returning: boolean) => {
-    set(() => ({
-      returningFromSearch: returning,
-    }))
-  },
-  setReturningFromSearchViaBackButton: (returning: boolean) => {
-    set(() => ({
-      returningFromSearchViaBackButton: returning,
     }))
   },
   setCachedSearchResults: (results: any[], title: string, subtitle: string, refTitles?: string[], refImages?: string[]) => {
@@ -160,6 +147,11 @@ export const createUISlice: StateCreator<StoreSlices, [], [], UISlice> = (set) =
   setSearchResultsSheetOpen: (open: boolean) => {
     set(() => ({
       isSearchResultsSheetOpen: open,
+    }))
+  },
+  setReturningFromSearchNavigation: (returning: boolean) => {
+    set(() => ({
+      returningFromSearchNavigation: returning,
     }))
   },
   setCloseActiveBottomSheet: (closeFunction: (() => void) | null) => {


### PR DESCRIPTION
- Prevented global cached results update in restoreSearchFromHistory to avoid triggering secondary expansion
- Added returningFromSearchNavigation flag in onRestoreSearch to prevent double expansion
- Fixed timing issue by setting navigation flag before calling restoreSearchFromHistory
- Eliminated jittery sheet behavior when reviving from search history