### PR TITLE
lag changes 2 (Added an enabled switch to useSignedImageUrl so we can…

### DIFF
--- a/features/communities/feed-screen.tsx
+++ b/features/communities/feed-screen.tsx
@@ -177,6 +177,7 @@ const DirectoryRow = React.memo(({
   isVisible?: boolean
 }) => {
   const bookmarkScale = useSharedValue(1)
+  const avatarShouldLoad = isVisible !== false
 
   const bookmarkAnimatedStyle = useAnimatedStyle(() => ({
     transform: [{ scale: bookmarkScale.value }],
@@ -223,7 +224,13 @@ const DirectoryRow = React.memo(({
       onPress={onPress}
     >
       <View style={{ flexDirection: 'row', alignItems: 'center', gap: 10, flex: 1 }}>
-        <Avatar source={u.avatar_url} fallback={u.name} size={60} priority={isVisible ? 'must' : 'low'} />
+        <Avatar
+          source={u.avatar_url}
+          fallback={u.name}
+          size={60}
+          priority={avatarShouldLoad ? 'must' : 'low'}
+          enabled={avatarShouldLoad}
+        />
         <View style={{ flex: 1, marginLeft: 5, gap: 4 }}>
           <Text style={{ color: c.black, fontWeight: '700', fontSize: (s.$09 as number) + 1 }} numberOfLines={1} ellipsizeMode="tail">
             {u.name}
@@ -780,7 +787,7 @@ const viewabilityConfig = useRef({ itemVisiblePercentThreshold: 50 }).current
 
   const renderItem = useCallback(
     ({ item }: { item: FeedUser; index: number }) => {
-      const userVisible = visibleUserSet.has(item.id)
+      const userVisible = visibleUserSet.size === 0 || visibleUserSet.has(item.id)
       return (
         <DirectoryRow
           u={item}

--- a/ui/atoms/Avatar.tsx
+++ b/ui/atoms/Avatar.tsx
@@ -11,6 +11,7 @@ type AvatarProps = {
   size: number
   fallback?: string | null
   priority?: 'must' | 'low'
+  enabled?: boolean
 }
 
 const deriveInitial = (text?: string | null) => {
@@ -19,7 +20,7 @@ const deriveInitial = (text?: string | null) => {
   return trimmed[0]?.toUpperCase() ?? ''
 }
 
-export const Avatar = ({ source, size, fallback, priority = 'low' }: AvatarProps) => {
+export const Avatar = ({ source, size, fallback, priority = 'low', enabled = true }: AvatarProps) => {
   const finalSize = typeof size === 'number' ? size : 32
   const bucket = nearestBucket(finalSize)
   const deviceScale = currentDpr()
@@ -31,7 +32,7 @@ export const Avatar = ({ source, size, fallback, priority = 'low' }: AvatarProps
       width: bucket * deviceScale,
       height: bucket * deviceScale,
     },
-    { priority }
+    { priority, enabled }
   )
 
   const circleStyle = {

--- a/ui/profiles/OtherProfileAvatarZoom.tsx
+++ b/ui/profiles/OtherProfileAvatarZoom.tsx
@@ -94,10 +94,6 @@ export const OtherProfileAvatarZoom = () => {
     }
   }, [otherProfileBackdropAnimatedIndex, unregisterBackdropPress])
 
-  if (!avatarZoomVisible || !avatarZoomImageUrl) {
-    return null
-  }
-
   const clamp = (value: number, lower: number, upper: number): number => {
     'worklet'
     return Math.min(Math.max(value, lower), upper)
@@ -115,6 +111,10 @@ export const OtherProfileAvatarZoom = () => {
     opacity: overlayOpacity.value,
     transform: [{ scale: overlayScale.value * pinchScale.value }],
   }))
+
+  if (!avatarZoomVisible || !avatarZoomImageUrl) {
+    return null
+  }
 
   return (
     <Pressable 


### PR DESCRIPTION
… skip scheduling Pinata signatures until an image is actually needed. When enabled is false the hook aborts any in‑flight request, reuses cached data if available, and avoids enqueuing new idle tasks.

Updated Avatar to accept that switch and only request signatures when explicitly enabled. In the directory row we now enable avatars only when the cell is (or is about to be) on screen; others stay in placeholder mode until they scroll into view. Initial rows still render immediately, later rows light up as soon as onViewableItemsChanged marks them visible. This trims the initial burst of 80+ signature jobs without adding timers or heavy gating, so the directory loads fast while keeping profile prefetch intact.)